### PR TITLE
Use Network UUID instead of ID (Sync with network store changes)

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import javax.inject.Inject;
+import java.util.UUID;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
@@ -30,36 +31,36 @@ public class SingleLineDiagramController {
     @Inject
     private SingleLineDiagramService singleLineDiagramService;
 
-    @GetMapping(value = "/svg/{networkId}/{voltageLevelId}", produces = MediaType.APPLICATION_XML_VALUE)
+    @GetMapping(value = "/svg/{networkUuid}/{voltageLevelId}", produces = MediaType.APPLICATION_XML_VALUE)
     @ApiOperation(value = "Get voltage level image", response = StreamingResponseBody.class)
     @ApiResponses(value = {@ApiResponse(code = 200, message = "The voltage level SVG")})
     public @ResponseBody String getVoltageLevelSvg(
-            @ApiParam(value = "Network ID") @PathVariable("networkId") String networkId,
+            @ApiParam(value = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
             @ApiParam(value = "VoltageLevel ID") @PathVariable("voltageLevelId") String voltageLevelId) {
-        LOGGER.debug("getVoltageLevelSvg request received with parameter networkId = {}, voltageLevelID = {}", networkId, voltageLevelId);
+        LOGGER.debug("getVoltageLevelSvg request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        return singleLineDiagramService.generateSvgAndMetadata(networkId, voltageLevelId).getLeft();
+        return singleLineDiagramService.generateSvgAndMetadata(networkUuid, voltageLevelId).getLeft();
     }
 
-    @GetMapping(value = "/metadata/{networkId}/{voltageLevelId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/metadata/{networkUuid}/{voltageLevelId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get the voltage level svg metadata", response = StreamingResponseBody.class)
     @ApiResponses(value = {@ApiResponse(code = 200, message = "The voltage level SVG metadata")})
     public @ResponseBody String getVoltageLevelMetadata(
-            @ApiParam(value = "Network ID") @PathVariable("networkId") String networkId,
+            @ApiParam(value = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
             @ApiParam(value = "VoltageLevel ID") @PathVariable("voltageLevelId") String voltageLevelId) {
-        LOGGER.debug("getVoltageLevelMetadata request received with parameter networkId = {}, voltageLevelID = {}", networkId, voltageLevelId);
+        LOGGER.debug("getVoltageLevelMetadata request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        return singleLineDiagramService.generateSvgAndMetadata(networkId, voltageLevelId).getRight();
+        return singleLineDiagramService.generateSvgAndMetadata(networkUuid, voltageLevelId).getRight();
     }
 
-    @GetMapping(value = "svg-and-metadata/{networkId}/{voltageLevelId}", produces = "application/zip")
+    @GetMapping(value = "svg-and-metadata/{networkUuid}/{voltageLevelId}", produces = "application/zip")
     @ApiOperation(value = "Get voltage level svg and metadata", response = StreamingResponseBody.class)
     @ApiResponses(value = {@ApiResponse(code = 200, message = "The voltage level svg and metadata")})
     public @ResponseBody byte[] getVoltageLevelFullSvg(
-            @ApiParam(value = "Network ID") @PathVariable("networkId") String networkId,
+            @ApiParam(value = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
             @ApiParam(value = "VoltageLevel ID") @PathVariable("voltageLevelId") String voltageLevelId) {
-        LOGGER.debug("getVoltageLevelCompleteSvg request received with parameter networkId = {}, voltageLevelID = {}", networkId, voltageLevelId);
+        LOGGER.debug("getVoltageLevelCompleteSvg request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        return singleLineDiagramService.generateSvgAndMetadataZip(networkId, voltageLevelId);
+        return singleLineDiagramService.generateSvgAndMetadataZip(networkUuid, voltageLevelId);
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -30,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -47,11 +48,11 @@ class SingleLineDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
-    private Network getNetwork(String networkId) {
+    private Network getNetwork(UUID networkUuid) {
         try {
-            return networkStoreService.getNetwork(networkId);
+            return networkStoreService.getNetwork(networkUuid);
         } catch (PowsyblException e) {
-            throw new ResponseStatusException(HttpStatus.NO_CONTENT, "Network '" + networkId + "' not found");
+            throw new ResponseStatusException(HttpStatus.NO_CONTENT, "Network '" + networkUuid + "' not found");
         }
     }
 
@@ -65,8 +66,8 @@ class SingleLineDiagramService {
         return VoltageLevelDiagram.build(graphBuilder, voltageLevelId, voltageLevelLayoutFactory, false, false);
     }
 
-    Pair<String, String> generateSvgAndMetadata(String networkId, String voltageLevelId) {
-        Network network = getNetwork(networkId);
+    Pair<String, String> generateSvgAndMetadata(UUID networkUuid, String voltageLevelId) {
+        Network network = getNetwork(networkUuid);
 
         VoltageLevelDiagram voltageLevelDiagram = createVoltageLevelDiagram(network, voltageLevelId);
 
@@ -92,8 +93,8 @@ class SingleLineDiagramService {
         }
     }
 
-    byte[] generateSvgAndMetadataZip(String networkId, String voltageLevelId) {
-        Pair<String, String> svgAndMetadata = generateSvgAndMetadata(networkId, voltageLevelId);
+    byte[] generateSvgAndMetadataZip(UUID networkUuid, String voltageLevelId) {
+        Pair<String, String> svgAndMetadata = generateSvgAndMetadata(networkUuid, voltageLevelId);
 
         try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
              ZipOutputStream zipOutputStream = new ZipOutputStream(new BufferedOutputStream(byteArrayOutputStream))) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: single-line-diagram
+    name: single-line-diagram-server
 
 server:
   port: 5005

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -50,10 +51,13 @@ public class SingleLineDiagramTest {
 
     @Test
     public void test() throws Exception {
-        given(networkStoreService.getNetwork("test")).willReturn(createNetwork());
-        given(networkStoreService.getNetwork("notFound")).willThrow(new PowsyblException());
+        UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+        UUID notFoundNetworkId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-        MvcResult result = mvc.perform(get("/v1/svg/{networkId}/{voltageLevelId}/", "test", "vlFr1A"))
+        given(networkStoreService.getNetwork(testNetworkId)).willReturn(createNetwork());
+        given(networkStoreService.getNetwork(notFoundNetworkId)).willThrow(new PowsyblException());
+
+        MvcResult result = mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
                 .andReturn();
@@ -61,37 +65,36 @@ public class SingleLineDiagramTest {
         assertEquals("<?xml", result.getResponse().getContentAsString().substring(0, 5));
 
         //voltage level not existing
-        mvc.perform(get("/v1/svg/{networkId}/{voltageLevelId}/", "test", "notFound"))
+        mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", testNetworkId, "notFound"))
                 .andExpect(status().isNoContent());
 
         //network not existing
-        mvc.perform(get("/v1/svg/{networkId}/{voltageLevelId}/", "notFound", "vlFr1A"))
+        mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", notFoundNetworkId, "vlFr1A"))
                 .andExpect(status().isNoContent());
 
-        mvc.perform(get("/v1/metadata/{networkId}/{voltageLevelId}/", "test", "vlFr1A"))
+        mvc.perform(get("/v1/metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
 
         //voltage level not existing
-        mvc.perform(get("/v1/metadata/{networkId}/{voltageLevelId}/", "test", "NotFound"))
+        mvc.perform(get("/v1/metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "NotFound"))
                 .andExpect(status().isNoContent());
 
         //network not existing
-        mvc.perform(get("/v1/metadata/{networkId}/{voltageLevelId}/", "notFound", "vlFr1A"))
+        mvc.perform(get("/v1/metadata/{networkUuid}/{voltageLevelId}/", notFoundNetworkId, "vlFr1A"))
                 .andExpect(status().isNoContent());
 
-        mvc.perform(get("/v1/svg-and-metadata/{networkId}/{voltageLevelId}/", "test", "vlFr1A"))
+        mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType("application/zip"));
 
         //voltage level not existing
-        mvc.perform(get("/v1/svg-and-metadata/{networkId}/{voltageLevelId}/", "test", "NotFound"))
+        mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "NotFound"))
                 .andExpect(status().isNoContent());
 
         //network not existing
-        mvc.perform(get("/v1/svg-and-metadata/{networkId}/{voltageLevelId}/", "notFound", "vlFr1A"))
+        mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", notFoundNetworkId, "vlFr1A"))
                 .andExpect(status().isNoContent());
-
     }
 
     public static Network createNetwork() {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
An evolution has been done on network store project to replace network IDs by UUIDs. So this PR adapt code to use new version of the network store client and also replace ID by UUID in REST API.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
