### PR TITLE
Fix SVG mime type + set content disposition in heep header for zip file

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -99,11 +99,11 @@ class SingleLineDiagramService {
         try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
              ZipOutputStream zipOutputStream = new ZipOutputStream(new BufferedOutputStream(byteArrayOutputStream))) {
 
-            zipOutputStream.putNextEntry(new ZipEntry("svg"));
+            zipOutputStream.putNextEntry(new ZipEntry(voltageLevelId + ".svg"));
             zipOutputStream.write(svgAndMetadata.getLeft().getBytes(StandardCharsets.UTF_8));
             zipOutputStream.closeEntry();
 
-            zipOutputStream.putNextEntry(new ZipEntry("metadata"));
+            zipOutputStream.putNextEntry(new ZipEntry(voltageLevelId + ".json"));
             zipOutputStream.write(svgAndMetadata.getRight().getBytes(StandardCharsets.UTF_8));
             zipOutputStream.closeEntry();
 

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -59,7 +59,7 @@ public class SingleLineDiagramTest {
 
         MvcResult result = mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+                .andExpect(content().contentTypeCompatibleWith(SingleLineDiagramController.IMAGE_SVG_PLUS_XML))
                 .andReturn();
 
         assertEquals("<?xml", result.getResponse().getContentAsString().substring(0, 5));
@@ -86,7 +86,7 @@ public class SingleLineDiagramTest {
 
         mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/zip"));
+                .andExpect(content().contentType(SingleLineDiagramController.APPLICATION_ZIP));
 
         //voltage level not existing
         mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "NotFound"))


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Mime type for svg is not correct and should be image/svg+xml.


**What is the new behavior (if this is a feature change)?**
Mime type is now correct.
Also content disposition is set in http header of svg + metadata zip for having download option available in Swagger UI.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
