### PR TITLE
Fix Sonar cloud coverage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,11 +26,11 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Build with Maven
-        run: mvn --batch-mode package
+        run: mvn --batch-mode -Pjacoco install
 
       - name: Run SonarCloud analysis
         run: >
-          mvn --batch-mode -Pjacoco package sonar:sonar
+          mvn --batch-mode -DskipTests sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=powsybl-ci-github
           -Dsonar.projectKey=com.powsybl:powsybl-single-line-diagram-server

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,12 @@
         <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.install.version>2.5.2</maven.install.version>
-        <maven.jacoco.version>0.8.1</maven.jacoco.version>
+        <maven.jacoco.version>0.8.2</maven.jacoco.version>
         <maven.resources.version>3.1.0</maven.resources.version>
         <maven.site.version>3.7.1</maven.site.version>
         <maven.surefire.version>2.22.0</maven.surefire.version>
 
+        <guava.version>20.0</guava.version>
         <jib.version>1.0.0</jib.version>
         <mockito.version>2.28.2</mockito.version>
         <springboot.version>2.1.3.RELEASE</springboot.version>
@@ -186,6 +187,13 @@
                                     <goal>prepare-agent</goal>
                                 </goals>
                             </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -205,7 +213,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>20.0</version>
+                <version>${guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Sonar cloud coverage is broken as jacoco.exec support has been removed.


**What is the new behavior (if this is a feature change)?**
jacoco.xml is generated instead of jacoco.exec


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
