### PR TITLE
Use nominal voltage color

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -21,6 +21,7 @@ import com.powsybl.sld.svg.DefaultDiagramInitialValueProvider;
 import com.powsybl.sld.svg.DefaultDiagramStyleProvider;
 import com.powsybl.sld.svg.DefaultNodeLabelConfiguration;
 import com.powsybl.sld.svg.DefaultSVGWriter;
+import com.powsybl.sld.util.NominalVoltageDiagramStyleProvider;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -76,7 +77,7 @@ class SingleLineDiagramService {
 
             DefaultSVGWriter defaultSVGWriter = new DefaultSVGWriter(COMPONENT_LIBRARY, LAYOUT_PARAMETERS);
             DefaultDiagramInitialValueProvider defaultDiagramInitialValueProvider = new DefaultDiagramInitialValueProvider(network);
-            DefaultDiagramStyleProvider defaultDiagramStyleProvider = new DefaultDiagramStyleProvider(network);
+            DefaultDiagramStyleProvider defaultDiagramStyleProvider = new NominalVoltageDiagramStyleProvider(network);
             DefaultNodeLabelConfiguration defaultNodeLabelConfiguration = new DefaultNodeLabelConfiguration(COMPONENT_LIBRARY);
 
             voltageLevelDiagram.writeSvg("",


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Default style provider is used to generate diagrams.


**What is the new behavior (if this is a feature change)?**
Waiting for topological style provider to work with new IIDM impl, we use nominal voltage style provider.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
