### PR TITLE
Respond with 404 instead of 204 on missing network or voltage level

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -53,14 +53,14 @@ class SingleLineDiagramService {
         try {
             return networkStoreService.getNetwork(networkUuid);
         } catch (PowsyblException e) {
-            throw new ResponseStatusException(HttpStatus.NO_CONTENT, "Network '" + networkUuid + "' not found");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Network '" + networkUuid + "' not found");
         }
     }
 
     private static VoltageLevelDiagram createVoltageLevelDiagram(Network network, String voltageLevelId, boolean useName) {
         VoltageLevel voltageLevel = network.getVoltageLevel(voltageLevelId);
         if (voltageLevel == null) {
-            throw new ResponseStatusException(HttpStatus.NO_CONTENT, "Voltage level " + voltageLevelId + " not found");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level " + voltageLevelId + " not found");
         }
         VoltageLevelLayoutFactory voltageLevelLayoutFactory = new SmartVoltageLevelLayoutFactory(network);
         GraphBuilder graphBuilder = new NetworkGraphBuilder(network);

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -66,11 +66,11 @@ public class SingleLineDiagramTest {
 
         //voltage level not existing
         mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", testNetworkId, "notFound"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
 
         //network not existing
         mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", notFoundNetworkId, "vlFr1A"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
 
         mvc.perform(get("/v1/metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
@@ -78,11 +78,11 @@ public class SingleLineDiagramTest {
 
         //voltage level not existing
         mvc.perform(get("/v1/metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "NotFound"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
 
         //network not existing
         mvc.perform(get("/v1/metadata/{networkUuid}/{voltageLevelId}/", notFoundNetworkId, "vlFr1A"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
 
         mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
@@ -90,11 +90,11 @@ public class SingleLineDiagramTest {
 
         //voltage level not existing
         mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", testNetworkId, "NotFound"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
 
         //network not existing
         mvc.perform(get("/v1/svg-and-metadata/{networkUuid}/{voltageLevelId}/", notFoundNetworkId, "vlFr1A"))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isNotFound());
     }
 
     public static Network createNetwork() {


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
sld-server returns 204 for non existing vl or networks


**What is the new behavior (if this is a feature change)?**
sld-server returns 404 for non existing vl or networks

