### PR TITLE
Activate adapt cell heigh to content by default

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -41,7 +41,8 @@ class SingleLineDiagramService {
 
     private static final ResourcesComponentLibrary COMPONENT_LIBRARY = new ResourcesComponentLibrary("/ConvergenceLibrary");
 
-    private static final LayoutParameters LAYOUT_PARAMETERS = new LayoutParameters();
+    private static final LayoutParameters LAYOUT_PARAMETERS = new LayoutParameters()
+            .setAdaptCellHeightToContent(true);
 
     @Autowired
     private NetworkStoreService networkStoreService;


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Cell height is fixed


**What is the new behavior (if this is a feature change)?**
Cell height is adapted to content


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
