### PR TITLE
indicate open lines

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -46,7 +46,7 @@ class SingleLineDiagramService {
 
     private static final LayoutParameters LAYOUT_PARAMETERS = new LayoutParameters()
             .setAdaptCellHeightToContent(true)
-            .setIndicateOpenLines(true);
+            .setHighlightLineState(true);
 
     @Autowired
     private NetworkStoreService networkStoreService;

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -45,7 +45,8 @@ class SingleLineDiagramService {
     private static final ResourcesComponentLibrary COMPONENT_LIBRARY = new ResourcesComponentLibrary("/ConvergenceLibrary");
 
     private static final LayoutParameters LAYOUT_PARAMETERS = new LayoutParameters()
-            .setAdaptCellHeightToContent(true);
+            .setAdaptCellHeightToContent(true)
+            .setIndicateOpenLines(true);
 
     @Autowired
     private NetworkStoreService networkStoreService;
@@ -83,7 +84,7 @@ class SingleLineDiagramService {
             DefaultSVGWriter defaultSVGWriter = new DefaultSVGWriter(COMPONENT_LIBRARY, renderedLayout);
             DefaultDiagramInitialValueProvider defaultDiagramInitialValueProvider = new DefaultDiagramInitialValueProvider(network);
             DefaultDiagramStyleProvider defaultDiagramStyleProvider = topologicalColoring ? new TopologicalStyleProvider(network)
-                                                                                          : new NominalVoltageDiagramStyleProvider();
+                                                                                          : new NominalVoltageDiagramStyleProvider(network);
             DefaultNodeLabelConfiguration defaultNodeLabelConfiguration = new DefaultNodeLabelConfiguration(COMPONENT_LIBRARY, renderedLayout);
 
             voltageLevelDiagram.writeSvg("",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature



**What is the current behavior?** *(You can also link to an open issue here)*
Open lines (on one or both ends) are not graphically distinguished from closed lines.



**What is the new behavior (if this is a feature change)?**
Open lines (on one or both ends) are graphically distinguished from closed lines, with colored/black plain/dashed line.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
