### PR TITLE
fixup, oops jackson version override was not working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,19 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- overrides of imports -->
+
+            <!-- The version 2.10 put by Powsybl cause a problem. spring boot 2.6 needs at least 2.13: https://github.com/FasterXML/jackson-databind/issues/2683 -->
+            <!-- java.lang.NoSuchMethodError: 'boolean com.fasterxml.jackson.databind.SerializationConfig.hasExplicitTimeZone()' -->
+            <!-- Use the version from spring boot 2.6.6 which contains the fix for the  spring 4 shell CVE -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- imports -->
             <dependency>
                 <groupId>com.powsybl</groupId>
@@ -112,17 +125,6 @@
             </dependency>
 
             <!-- project specific dependencies (also overrides imports, but separate for clarity) -->
-
-            <!-- The version 2.10 put by Powsybl cause a problem. spring boot 2.6 needs at least 2.13: https://github.com/FasterXML/jackson-databind/issues/2683 -->
-            <!-- java.lang.NoSuchMethodError: 'boolean com.fasterxml.jackson.databind.SerializationConfig.hasExplicitTimeZone()' -->
-            <!-- Use the version from spring boot 2.6.6 which contains the fix for the  spring 4 shell CVE -->
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/StreamReadCapability


**What is the new behavior (if this is a feature change)?**
no exception


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO