### PR TITLE
get network area diagram

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <powsybl-core.version>4.7.0</powsybl-core.version>
         <powsybl-single-line-diagram.version>2.9.1</powsybl-single-line-diagram.version>
         <powsybl.nad.version>0.3.0</powsybl.nad.version>
-<!--        <slf4j.version>1.7.22</slf4j.version>-->
 
         <powsybl-network-store.version>1.0.0-SNAPSHOT</powsybl-network-store.version>
         <powsybl-ws-commons.version>1.1.0</powsybl-ws-commons.version>
@@ -128,11 +127,6 @@
             </dependency>
 
             <!-- project specific dependencies (also overrides imports, but separate for clarity) -->
-<!--            <dependency>-->
-<!--                <groupId>org.slf4j</groupId>-->
-<!--                <artifactId>slf4j-simple</artifactId>-->
-<!--                <version>${slf4j.version}</version>-->
-<!--            </dependency>-->
             <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,9 @@
 
         <powsybl-core.version>4.7.0</powsybl-core.version>
         <powsybl-single-line-diagram.version>2.9.1</powsybl-single-line-diagram.version>
+        <powsybl.nad.version>0.3.0</powsybl.nad.version>
+<!--        <slf4j.version>1.7.22</slf4j.version>-->
+
         <powsybl-network-store.version>1.0.0-SNAPSHOT</powsybl-network-store.version>
         <powsybl-ws-commons.version>1.1.0</powsybl-ws-commons.version>
     </properties>
@@ -125,10 +128,20 @@
             </dependency>
 
             <!-- project specific dependencies (also overrides imports, but separate for clarity) -->
+<!--            <dependency>-->
+<!--                <groupId>org.slf4j</groupId>-->
+<!--                <artifactId>slf4j-simple</artifactId>-->
+<!--                <version>${slf4j.version}</version>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>
                 <version>${springdoc-openapi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-network-area-diagram</artifactId>
+                <version>${powsybl.nad.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>
@@ -150,6 +163,10 @@
 
     <dependencies>
         <!-- Compilation dependencies -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-area-diagram</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-network-store-client</artifactId>

--- a/src/main/java/com/powsybl/sld/server/DiagramUtils.java
+++ b/src/main/java/com/powsybl/sld/server/DiagramUtils.java
@@ -25,8 +25,4 @@ public final class DiagramUtils {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
-
-    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
-        return getNetwork(networkUuid, variantId, networkStoreService, null);
-    }
 }

--- a/src/main/java/com/powsybl/sld/server/DiagramUtils.java
+++ b/src/main/java/com/powsybl/sld/server/DiagramUtils.java
@@ -1,0 +1,32 @@
+package com.powsybl.sld.server;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.network.store.client.PreloadingStrategy;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+public final class DiagramUtils {
+    private DiagramUtils() {
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService, PreloadingStrategy preloadingStrategy) {
+        try {
+            Network network = networkStoreService.getNetwork(networkUuid, preloadingStrategy);
+            if (variantId != null) {
+                network.getVariantManager().setWorkingVariant(variantId);
+            }
+            return network;
+        } catch (PowsyblException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
+        return getNetwork(networkUuid, variantId, networkStoreService, null);
+    }
+}

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -19,6 +19,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -30,14 +31,16 @@ class NetworkAreaDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
-    public String generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, String voltageLevelId, int depth) {
+    public String generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, List<String> voltageLevelsIds, int depth) {
         Network network = SingleLineDiagramService.getNetwork(networkUuid, variantId, networkStoreService);
-        if (network.getVoltageLevel(voltageLevelId) == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level" + voltageLevelId + " not found");
-        }
+        voltageLevelsIds.forEach(voltageLevelId -> {
+            if (network.getVoltageLevel(voltageLevelId) == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level" + voltageLevelId + " not found");
+            }
+        });
 
         try (StringWriter svgWriter = new StringWriter()) {
-            new NetworkAreaDiagram(network, voltageLevelId, depth).draw(svgWriter, new SvgParameters().setSvgWidthAndHeightAdded(true));
+            new NetworkAreaDiagram(network, voltageLevelsIds, depth).draw(svgWriter, new SvgParameters().setSvgWidthAndHeightAdded(true));
 
             return svgWriter.toString();
         } catch (IOException e) {

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.nad.NetworkAreaDiagram;
 import com.powsybl.nad.svg.SvgParameters;
 import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.network.store.client.PreloadingStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
@@ -32,7 +33,7 @@ class NetworkAreaDiagramService {
     private NetworkStoreService networkStoreService;
 
     public String generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, List<String> voltageLevelsIds, int depth) {
-        Network network = SingleLineDiagramService.getNetwork(networkUuid, variantId, networkStoreService);
+        Network network = SingleLineDiagramService.getNetwork(networkUuid, variantId, networkStoreService, PreloadingStrategy.COLLECTION);
         voltageLevelsIds.forEach(voltageLevelId -> {
             if (network.getVoltageLevel(voltageLevelId) == null) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level" + voltageLevelId + " not found");

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -41,8 +41,10 @@ class NetworkAreaDiagramService {
         });
 
         try (StringWriter svgWriter = new StringWriter()) {
-            new NetworkAreaDiagram(network, voltageLevelsIds, depth).draw(svgWriter, new SvgParameters().setSvgWidthAndHeightAdded(true));
-
+            new NetworkAreaDiagram(network, voltageLevelsIds, depth).draw(
+                    svgWriter,
+                    new SvgParameters().setSvgWidthAndHeightAdded(true).setTextNodeBackground(false).setCssLocation(SvgParameters.CssLocation.EXTERNAL_NO_IMPORT)
+            );
             return svgWriter.toString();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -11,6 +11,7 @@ import com.powsybl.nad.NetworkAreaDiagram;
 import com.powsybl.nad.svg.SvgParameters;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.client.PreloadingStrategy;
+import com.powsybl.sld.utils.DiagramUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -31,20 +31,9 @@ class NetworkAreaDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
-    private Network getNetwork(UUID networkUuid, String variantId) {
-        try {
-            Network network = networkStoreService.getNetwork(networkUuid);
-            if (variantId != null) {
-                network.getVariantManager().setWorkingVariant(variantId);
-            }
-            return network;
-        } catch (PowsyblException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-    }
 
     public String generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, String voltageLevelId, int depth) {
-        Network network = getNetwork(networkUuid, variantId);
+        Network network = SingleLineDiagramService.getNetwork(networkUuid, variantId, networkStoreService);
         if (network.getVoltageLevel(voltageLevelId) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level" + voltageLevelId + " not found");
         }

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.sld.server;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.nad.NetworkAreaDiagram;
 import com.powsybl.nad.svg.SvgParameters;
@@ -30,7 +29,6 @@ import java.util.UUID;
 class NetworkAreaDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
-
 
     public String generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, String voltageLevelId, int depth) {
         Network network = SingleLineDiagramService.getNetwork(networkUuid, variantId, networkStoreService);

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -33,7 +33,7 @@ class NetworkAreaDiagramService {
     private NetworkStoreService networkStoreService;
 
     public String generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, List<String> voltageLevelsIds, int depth) {
-        Network network = SingleLineDiagramService.getNetwork(networkUuid, variantId, networkStoreService, PreloadingStrategy.COLLECTION);
+        Network network = DiagramUtils.getNetwork(networkUuid, variantId, networkStoreService, PreloadingStrategy.COLLECTION);
         voltageLevelsIds.forEach(voltageLevelId -> {
             if (network.getVoltageLevel(voltageLevelId) == null) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level" + voltageLevelId + " not found");

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import static com.powsybl.ws.commons.LogUtils.sanitizeParam;
+
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
@@ -194,7 +196,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, voltageLevelsIds, depth);
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, sanitizeParam(voltageLevelsIds.toString()), depth);
 
         return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
     }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -194,7 +194,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", sanitizeParameter(networkUuid.toString()), sanitizeParameter(voltageLevelsIds.toString()), sanitizeParameter(String.valueOf(depth)));
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {0}, voltageLevelsIds = {1}, depth = {2}", sanitizeParameter(networkUuid.toString()), sanitizeParameter(voltageLevelsIds.toString()), sanitizeParameter(String.valueOf(depth)));
 
         return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
     }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -194,12 +194,12 @@ public class SingleLineDiagramController {
             @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", cleanParameter(networkUuid.toString()), cleanParameter(voltageLevelsIds.toString()), cleanParameter(String.valueOf(depth)));
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", sanitizeParameter(networkUuid.toString()), sanitizeParameter(voltageLevelsIds.toString()), sanitizeParameter(String.valueOf(depth)));
 
         return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
     }
 
-    public static String cleanParameter(String param) {
+    public static String sanitizeParameter(String param) {
         return param.replaceAll("[\n\r\t]", "_");
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -185,16 +186,16 @@ public class SingleLineDiagramController {
     }
 
     // network area diagram
-    @GetMapping(value = "/network-area-diagram/{networkUuid}/{voltageLevelId}", produces = IMAGE_SVG_PLUS_XML)
+    @GetMapping(value = "/network-area-diagram/{networkUuid}", produces = IMAGE_SVG_PLUS_XML)
     @Operation(summary = "Get network area diagram image")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The network area diagram svg")})
     public @ResponseBody String getNetworkAreaDiagramSvg(
             @Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
-            @Parameter(description = "VoltageLevel ID") @PathVariable("voltageLevelId") String voltageLevelUuid,
+            @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getSubstationSvg request received with parameter networkUuid = {}, depth = {}", networkUuid, depth);
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, voltageLevelsIds, depth);
 
-        return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelUuid, depth);
+        return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -194,12 +194,8 @@ public class SingleLineDiagramController {
             @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, sanitizeParameter(voltageLevelsIds.toString()), depth);
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, voltageLevelsIds, depth);
 
         return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
-    }
-
-    public static String sanitizeParameter(String param) {
-        return param.replaceAll("[\n\r\t]", "_");
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.server;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.RawValue;
-import com.powsybl.sld.utils.DiagramParameters;
+import com.powsybl.sld.utils.SingleLineDiagramParameters;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -45,6 +45,9 @@ public class SingleLineDiagramController {
     @Autowired
     private SingleLineDiagramService singleLineDiagramService;
 
+    @Autowired
+    private NetworkAreaDiagramService networkAeraDiagramService;
+
     // voltage levels
     //
     @GetMapping(value = "/svg/{networkUuid}/{voltageLevelId}", produces = IMAGE_SVG_PLUS_XML)
@@ -60,7 +63,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "topologicalColoring") @RequestParam(name = "topologicalColoring", defaultValue = "false") boolean topologicalColoring,
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getVoltageLevelSvg request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
-        var parameters = new DiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
         return singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, voltageLevelId, parameters).getLeft();
     }
 
@@ -78,7 +81,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getVoltageLevelMetadata request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        var parameters = new DiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
         return singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, voltageLevelId, parameters).getRight();
     }
 
@@ -96,7 +99,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) throws JsonProcessingException {
         LOGGER.debug("getVoltageLevelCompleteSvg request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        var parameters = new DiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
         Pair<String, String> svgAndMetadata = singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, voltageLevelId, parameters);
         String svg = svgAndMetadata.getLeft();
         String metadata = svgAndMetadata.getRight();
@@ -123,7 +126,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getSubstationSvg request received with parameter networkUuid = {}, substationID = {}", networkUuid, substationId);
 
-        var parameters = new DiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, substationLayout);
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, substationLayout);
         return singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, substationId, parameters).getLeft();
     }
 
@@ -142,7 +145,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getSubstationMetadata request received with parameter networkUuid = {}, substationID = {}", networkUuid, substationId);
 
-        var parameters = new DiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, substationLayout);
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, substationLayout);
         return singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, substationId, parameters).getRight();
     }
 
@@ -161,7 +164,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) throws JsonProcessingException {
         LOGGER.debug("getSubstationFullSvg request received with parameter networkUuid = {}, substationID = {}", networkUuid, substationId);
 
-        var parameters = new DiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, substationLayout);
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, substationLayout);
         Pair<String, String> svgAndMetadata = singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, substationId, parameters);
         String svg = svgAndMetadata.getLeft();
         String metadata = svgAndMetadata.getRight();
@@ -178,5 +181,19 @@ public class SingleLineDiagramController {
         LOGGER.debug("getAvailableSvgComponentLibraries ...");
         Collection<String> libraries = singleLineDiagramService.getAvailableSvgComponentLibraries();
         return ResponseEntity.ok().body(libraries);
+    }
+
+    // network area diagram
+    @GetMapping(value = "/network-area-diagram/{networkUuid}/{voltageLevelId}", produces = IMAGE_SVG_PLUS_XML)
+    @Operation(summary = "Get network area diagram image")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The network area diagram svg")})
+    public @ResponseBody String getNetworkAreaDiagramSvg(
+            @Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
+            @Parameter(description = "VoltageLevel ID") @PathVariable("voltageLevelId") String voltageLevelUuid,
+            @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
+            @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
+        LOGGER.debug("getSubstationSvg request received with parameter networkUuid = {}, depth = {}", networkUuid, depth);
+
+        return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelUuid, depth);
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -194,8 +194,12 @@ public class SingleLineDiagramController {
             @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, voltageLevelsIds, depth);
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", cleanParameter(networkUuid.toString()), cleanParameter(voltageLevelsIds.toString()), cleanParameter(String.valueOf(depth)));
 
         return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
+    }
+
+    public static String cleanParameter(String param) {
+        return param.replaceAll("[\n\r\t]", "_");
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -194,7 +194,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "Voltage levels ids") @RequestParam(name = "voltageLevelsIds", required = false) List<String> voltageLevelsIds,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) {
-        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {0}, voltageLevelsIds = {1}, depth = {2}", sanitizeParameter(networkUuid.toString()), sanitizeParameter(voltageLevelsIds.toString()), sanitizeParameter(String.valueOf(depth)));
+        LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, sanitizeParameter(voltageLevelsIds.toString()), depth);
 
         return networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
     }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -41,6 +41,7 @@ public class SingleLineDiagramController {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     static final String IMAGE_SVG_PLUS_XML = "image/svg+xml";
+    static final String HORIZONTAL = "horizontal";
 
     @Autowired
     private SingleLineDiagramService singleLineDiagramService;
@@ -63,7 +64,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "topologicalColoring") @RequestParam(name = "topologicalColoring", defaultValue = "false") boolean topologicalColoring,
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getVoltageLevelSvg request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
-        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, HORIZONTAL);
         return singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, voltageLevelId, parameters).getLeft();
     }
 
@@ -81,7 +82,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getVoltageLevelMetadata request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, HORIZONTAL);
         return singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, voltageLevelId, parameters).getRight();
     }
 
@@ -99,7 +100,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) throws JsonProcessingException {
         LOGGER.debug("getVoltageLevelCompleteSvg request received with parameter networkUuid = {}, voltageLevelID = {}", networkUuid, voltageLevelId);
 
-        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, "horizontal");
+        var parameters = new SingleLineDiagramParameters(useName, centerLabel, diagonalLabel, topologicalColoring, componentLibrary, HORIZONTAL);
         Pair<String, String> svgAndMetadata = singleLineDiagramService.generateSvgAndMetadata(networkUuid, variantId, voltageLevelId, parameters);
         String svg = svgAndMetadata.getLeft();
         String metadata = svgAndMetadata.getRight();
@@ -122,7 +123,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "centerLabel") @RequestParam(name = "centerLabel", defaultValue = "false") boolean centerLabel,
             @Parameter(description = "diagonalLabel") @RequestParam(name = "diagonalLabel", defaultValue = "false") boolean diagonalLabel,
             @Parameter(description = "topologicalColoring") @RequestParam(name = "topologicalColoring", defaultValue = "false") boolean topologicalColoring,
-            @Parameter(description = "substationLayout") @RequestParam(name = "substationLayout", defaultValue = "horizontal") String substationLayout,
+            @Parameter(description = "substationLayout") @RequestParam(name = "substationLayout", defaultValue = HORIZONTAL) String substationLayout,
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getSubstationSvg request received with parameter networkUuid = {}, substationID = {}", networkUuid, substationId);
 
@@ -141,7 +142,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "centerLabel") @RequestParam(name = "centerLabel", defaultValue = "false") boolean centerLabel,
             @Parameter(description = "diagonalLabel") @RequestParam(name = "diagonalLabel", defaultValue = "false") boolean diagonalLabel,
             @Parameter(description = "topologicalColoring") @RequestParam(name = "topologicalColoring", defaultValue = "false") boolean topologicalColoring,
-            @Parameter(description = "substationLayout") @RequestParam(name = "substationLayout", defaultValue = "horizontal") String substationLayout,
+            @Parameter(description = "substationLayout") @RequestParam(name = "substationLayout", defaultValue = HORIZONTAL) String substationLayout,
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) {
         LOGGER.debug("getSubstationMetadata request received with parameter networkUuid = {}, substationID = {}", networkUuid, substationId);
 
@@ -160,7 +161,7 @@ public class SingleLineDiagramController {
             @Parameter(description = "centerLabel") @RequestParam(name = "centerLabel", defaultValue = "false") boolean centerLabel,
             @Parameter(description = "diagonalLabel") @RequestParam(name = "diagonalLabel", defaultValue = "false") boolean diagonalLabel,
             @Parameter(description = "topologicalColoring") @RequestParam(name = "topologicalColoring", defaultValue = "false") boolean topologicalColoring,
-            @Parameter(description = "substationLayout") @RequestParam(name = "substationLayout", defaultValue = "horizontal") String substationLayout,
+            @Parameter(description = "substationLayout") @RequestParam(name = "substationLayout", defaultValue = HORIZONTAL) String substationLayout,
             @Parameter(description = "component library name") @RequestParam(name = "componentLibrary", defaultValue = GridSuiteAndConvergenceComponentLibrary.NAME) String componentLibrary) throws JsonProcessingException {
         LOGGER.debug("getSubstationFullSvg request received with parameter networkUuid = {}, substationID = {}", networkUuid, substationId);
 

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -46,6 +46,10 @@ class SingleLineDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
+    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
+        return DiagramUtils.getNetwork(networkUuid, variantId, networkStoreService, null);
+    }
+
     private static SubstationLayoutFactory getSubstationLayoutFactory(String substationLayout) {
         SubstationLayoutFactory substationLayoutFactory;
         switch (substationLayout) {
@@ -63,7 +67,7 @@ class SingleLineDiagramService {
     }
 
     Pair<String, String> generateSvgAndMetadata(UUID networkUuid, String variantId, String id, SingleLineDiagramParameters diagParams) {
-        Network network = DiagramUtils.getNetwork(networkUuid, variantId, networkStoreService);
+        Network network = getNetwork(networkUuid, variantId, networkStoreService);
         if (network.getVoltageLevel(id) == null && network.getSubstation(id) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level or substation " + id + " not found");
         }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -15,6 +15,7 @@ import com.powsybl.sld.library.ComponentLibrary;
 import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
 import com.powsybl.sld.util.NominalVoltageDiagramStyleProvider;
 import com.powsybl.sld.util.TopologicalStyleProvider;
+import com.powsybl.sld.utils.DiagramUtils;
 import com.powsybl.sld.utils.SingleLineDiagramParameters;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -9,7 +9,6 @@ package com.powsybl.sld.server;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.network.store.client.NetworkStoreService;
-import com.powsybl.network.store.client.PreloadingStrategy;
 import com.powsybl.sld.SingleLineDiagram;
 import com.powsybl.sld.layout.*;
 import com.powsybl.sld.library.ComponentLibrary;
@@ -47,22 +46,6 @@ class SingleLineDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
-    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService, PreloadingStrategy preloadingStrategy) {
-        try {
-            Network network = networkStoreService.getNetwork(networkUuid, preloadingStrategy);
-            if (variantId != null) {
-                network.getVariantManager().setWorkingVariant(variantId);
-            }
-            return network;
-        } catch (PowsyblException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-    }
-
-    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
-        return getNetwork(networkUuid, variantId, networkStoreService, null);
-    }
-
     private static SubstationLayoutFactory getSubstationLayoutFactory(String substationLayout) {
         SubstationLayoutFactory substationLayoutFactory;
         switch (substationLayout) {
@@ -80,7 +63,7 @@ class SingleLineDiagramService {
     }
 
     Pair<String, String> generateSvgAndMetadata(UUID networkUuid, String variantId, String id, SingleLineDiagramParameters diagParams) {
-        Network network = getNetwork(networkUuid, variantId, networkStoreService);
+        Network network = DiagramUtils.getNetwork(networkUuid, variantId, networkStoreService);
         if (network.getVoltageLevel(id) == null && network.getSubstation(id) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level or substation " + id + " not found");
         }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.server;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.network.store.client.PreloadingStrategy;
 import com.powsybl.sld.SingleLineDiagram;
 import com.powsybl.sld.layout.*;
 import com.powsybl.sld.library.ComponentLibrary;
@@ -46,9 +47,9 @@ class SingleLineDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
-    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
+    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService, PreloadingStrategy preloadingStrategy) {
         try {
-            Network network = networkStoreService.getNetwork(networkUuid);
+            Network network = networkStoreService.getNetwork(networkUuid, preloadingStrategy);
             if (variantId != null) {
                 network.getVariantManager().setWorkingVariant(variantId);
             }
@@ -56,6 +57,10 @@ class SingleLineDiagramService {
         } catch (PowsyblException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
+    }
+
+    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
+        return getNetwork(networkUuid, variantId, networkStoreService, null);
     }
 
     private static SubstationLayoutFactory getSubstationLayoutFactory(String substationLayout) {

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -15,7 +15,7 @@ import com.powsybl.sld.library.ComponentLibrary;
 import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
 import com.powsybl.sld.util.NominalVoltageDiagramStyleProvider;
 import com.powsybl.sld.util.TopologicalStyleProvider;
-import com.powsybl.sld.utils.DiagramParameters;
+import com.powsybl.sld.utils.SingleLineDiagramParameters;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -74,7 +74,7 @@ class SingleLineDiagramService {
         return substationLayoutFactory;
     }
 
-    Pair<String, String> generateSvgAndMetadata(UUID networkUuid, String variantId, String id, DiagramParameters diagParams) {
+    Pair<String, String> generateSvgAndMetadata(UUID networkUuid, String variantId, String id, SingleLineDiagramParameters diagParams) {
         Network network = getNetwork(networkUuid, variantId);
         if (network.getVoltageLevel(id) == null && network.getSubstation(id) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level or substation " + id + " not found");

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -46,7 +46,7 @@ class SingleLineDiagramService {
     @Autowired
     private NetworkStoreService networkStoreService;
 
-    private Network getNetwork(UUID networkUuid, String variantId) {
+    public static Network getNetwork(UUID networkUuid, String variantId, NetworkStoreService networkStoreService) {
         try {
             Network network = networkStoreService.getNetwork(networkUuid);
             if (variantId != null) {
@@ -75,7 +75,7 @@ class SingleLineDiagramService {
     }
 
     Pair<String, String> generateSvgAndMetadata(UUID networkUuid, String variantId, String id, SingleLineDiagramParameters diagParams) {
-        Network network = getNetwork(networkUuid, variantId);
+        Network network = getNetwork(networkUuid, variantId, networkStoreService);
         if (network.getVoltageLevel(id) == null && network.getSubstation(id) == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Voltage level or substation " + id + " not found");
         }

--- a/src/main/java/com/powsybl/sld/utils/DiagramUtils.java
+++ b/src/main/java/com/powsybl/sld/utils/DiagramUtils.java
@@ -1,4 +1,10 @@
-package com.powsybl.sld.server;
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.utils;
 
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Network;
@@ -9,6 +15,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.UUID;
 
+/**
+ * @author Etienne Homer<etienne.homer at rte-france.com>
+ */
 public final class DiagramUtils {
     private DiagramUtils() {
         throw new AssertionError("Utility class should not be instantiated");

--- a/src/main/java/com/powsybl/sld/utils/SingleLineDiagramParameters.java
+++ b/src/main/java/com/powsybl/sld/utils/SingleLineDiagramParameters.java
@@ -14,7 +14,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor
-public class DiagramParameters {
+public class SingleLineDiagramParameters {
     private boolean useName;
     private boolean labelCentered;
     private boolean diagonalLabel;

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.server;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.network.store.client.PreloadingStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,8 +60,8 @@ public class SingleLineDiagramTest {
         UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
         UUID notFoundNetworkId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-        given(networkStoreService.getNetwork(testNetworkId)).willReturn(createNetwork());
-        given(networkStoreService.getNetwork(notFoundNetworkId)).willThrow(new PowsyblException());
+        given(networkStoreService.getNetwork(testNetworkId, null)).willReturn(createNetwork());
+        given(networkStoreService.getNetwork(notFoundNetworkId, null)).willThrow(new PowsyblException());
 
         MvcResult result = mvc.perform(get("/v1/svg/{networkUuid}/{voltageLevelId}/", testNetworkId, "vlFr1A"))
                 .andExpect(status().isOk())
@@ -138,8 +139,8 @@ public class SingleLineDiagramTest {
         UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
         UUID notFoundNetworkId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-        given(networkStoreService.getNetwork(testNetworkId)).willReturn(createNetwork());
-        given(networkStoreService.getNetwork(notFoundNetworkId)).willThrow(new PowsyblException());
+        given(networkStoreService.getNetwork(testNetworkId, null)).willReturn(createNetwork());
+        given(networkStoreService.getNetwork(notFoundNetworkId, null)).willThrow(new PowsyblException());
 
         MvcResult result = mvc.perform(get("/v1/substation-svg/{networkUuid}/{substationId}/", testNetworkId, "subFr1"))
                 .andExpect(status().isOk())
@@ -228,8 +229,8 @@ public class SingleLineDiagramTest {
         UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
         UUID notFoundNetworkId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-        given(networkStoreService.getNetwork(testNetworkId)).willReturn(createNetwork());
-        given(networkStoreService.getNetwork(notFoundNetworkId)).willThrow(new PowsyblException());
+        given(networkStoreService.getNetwork(testNetworkId, PreloadingStrategy.COLLECTION)).willReturn(createNetwork());
+        given(networkStoreService.getNetwork(notFoundNetworkId, PreloadingStrategy.COLLECTION)).willThrow(new PowsyblException());
 
         MvcResult result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&depth=0" + "&voltageLevelsIds=vlFr1A", testNetworkId))
                 .andExpect(status().isOk())

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -223,6 +223,30 @@ public class SingleLineDiagramTest {
         assertEquals("[\"GridSuiteAndConvergence\",\"Convergence\"]", result.getResponse().getContentAsString());
     }
 
+    @Test
+    public void testNetworkAreaDiagram() throws Exception {
+        UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+        UUID notFoundNetworkId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+        given(networkStoreService.getNetwork(testNetworkId)).willReturn(createNetwork());
+        given(networkStoreService.getNetwork(notFoundNetworkId)).willThrow(new PowsyblException());
+
+        MvcResult result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}/{voltageLevelId}?variantId=" + VARIANT_2_ID + "&depth=0", testNetworkId, "vlFr1A"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(SingleLineDiagramController.IMAGE_SVG_PLUS_XML))
+                .andReturn();
+        assertEquals("<?xml", result.getResponse().getContentAsString().substring(0, 5));
+
+        result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}/{voltageLevelId}?variantId=" + VARIANT_2_ID + "&depth=2", testNetworkId, "vlFr1A"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(SingleLineDiagramController.IMAGE_SVG_PLUS_XML))
+                .andReturn();
+        assertEquals("<?xml", result.getResponse().getContentAsString().substring(0, 5));
+
+        mvc.perform(get("/v1/network-area-diagram/{networkUuid}/{voltageLevelId}?variantId=" + VARIANT_2_ID + "&depth=2", testNetworkId, "notFound"))
+                .andExpect(status().isNotFound());
+    }
+
     public static Network createNetwork() {
         Network network = Network.create("test", "test");
         Substation substationFr1 = network.newSubstation()

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -231,19 +231,19 @@ public class SingleLineDiagramTest {
         given(networkStoreService.getNetwork(testNetworkId)).willReturn(createNetwork());
         given(networkStoreService.getNetwork(notFoundNetworkId)).willThrow(new PowsyblException());
 
-        MvcResult result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}/{voltageLevelId}?variantId=" + VARIANT_2_ID + "&depth=0", testNetworkId, "vlFr1A"))
+        MvcResult result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&depth=0" + "&voltageLevelsIds=vlFr1A", testNetworkId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(SingleLineDiagramController.IMAGE_SVG_PLUS_XML))
                 .andReturn();
         assertEquals("<?xml", result.getResponse().getContentAsString().substring(0, 5));
 
-        result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}/{voltageLevelId}?variantId=" + VARIANT_2_ID + "&depth=2", testNetworkId, "vlFr1A"))
+        result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&depth=2" + "&voltageLevelsIds=vlFr1A", testNetworkId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(SingleLineDiagramController.IMAGE_SVG_PLUS_XML))
                 .andReturn();
         assertEquals("<?xml", result.getResponse().getContentAsString().substring(0, 5));
 
-        mvc.perform(get("/v1/network-area-diagram/{networkUuid}/{voltageLevelId}?variantId=" + VARIANT_2_ID + "&depth=2", testNetworkId, "notFound"))
+        mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&depth=2" + "&voltageLevelsIds=notFound", testNetworkId))
                 .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
Signed-off-by: Etienne Homer <etiennehomer@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature: getting Network Area Diagram SVG

**What is the current behavior?** *(You can also link to an open issue here)*
NAD genreration is not implemented.


**What is the new behavior (if this is a feature change)?**
We have an endpoint to get the svg of a network area.
