### PR TITLE
restore sonar comment passing from push On to push PR

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - 'main'
+      - 'release-v**'
+  pull_request:
   repository_dispatch:
     types:
       - network_store_updated


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
no sonar comment in CI


**What is the new behavior (if this is a feature change)?**
sonar comment in CI


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
sonarcloud changed