### PR TITLE
Fix 'diagonal label' parameter overwritten in state variable sld mode

### DIFF
--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramService.java
@@ -95,7 +95,6 @@ class SingleLineDiagramService {
                 labelProvider = new PositionDiagramLabelProvider(network, compLibrary, layoutParameters, id);
             } else if (diagParams.getSldDisplayMode() == SldDisplayMode.STATE_VARIABLE) {
                 layoutParameters.setAddNodesInfos(true);
-                layoutParameters.setLabelDiagonal(false);
                 labelProvider = new DefaultDiagramLabelProvider(network, compLibrary, layoutParameters);
             } else {
                 throw new PowsyblException(String.format("Given sld display mode %s doesn't exist", diagParams.getSldDisplayMode()));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Feeder labels are not displayed in diagonal anymore, when this parameter is set


**What is the new behavior (if this is a feature change)?**
Feeder labels are now displayed in diagonal, when this parameter is set


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
