### PR TITLE
Get number of voltage levels in diagram

### DIFF
--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -8,6 +8,7 @@ package com.powsybl.sld.server;
 
 import com.powsybl.iidm.network.Network;
 import com.powsybl.nad.NetworkAreaDiagram;
+import com.powsybl.nad.build.iidm.VoltageLevelFilter;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.svg.StyleProvider;
 import com.powsybl.nad.svg.SvgParameters;
@@ -45,15 +46,16 @@ class NetworkAreaDiagramService {
             }
         });
 
+        VoltageLevelFilter vlFilter = VoltageLevelFilter.createVoltageLevelsDepthFilter(network, voltageLevelsIds, depth);
+
         try (StringWriter svgWriter = new StringWriter()) {
             SvgParameters svgParameters = new SvgParameters()
                     .setSvgWidthAndHeightAdded(true)
                     .setCssLocation(SvgParameters.CssLocation.EXTERNAL_NO_IMPORT);
             LayoutParameters layoutParameters = new LayoutParameters();
             StyleProvider styleProvider = new TopologicalStyleProvider(network);
-            NetworkAreaDiagram diagram = new NetworkAreaDiagram(network, voltageLevelsIds, depth);
-            diagram.draw(svgWriter, svgParameters, layoutParameters, styleProvider);
-            return Pair.of(svgWriter.toString(), diagram.getNbVoltageLevels());
+            new NetworkAreaDiagram(network, voltageLevelsIds, depth).draw(svgWriter, svgParameters, layoutParameters, styleProvider);
+            return Pair.of(svgWriter.toString(), vlFilter.getNbVoltageLevels());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -47,12 +47,13 @@ public class SingleLineDiagramController {
     static final String IMAGE_SVG_PLUS_XML = "image/svg+xml";
     static final String HORIZONTAL = "horizontal";
     static final String SVG_TAG = "svg";
+    static final String NB_VOLTAGE_LEVELS_TAG = "nbVoltageLevels";
 
     @Autowired
     private SingleLineDiagramService singleLineDiagramService;
 
     @Autowired
-    private NetworkAreaDiagramService networkAeraDiagramService;
+    private NetworkAreaDiagramService networkAreaDiagramService;
 
     // voltage levels
     //
@@ -261,10 +262,11 @@ public class SingleLineDiagramController {
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "depth") @RequestParam(name = "depth", required = false) int depth) throws JsonProcessingException {
         LOGGER.debug("getNetworkAreaDiagramSvg request received with parameter networkUuid = {}, voltageLevelsIds = {}, depth = {}", networkUuid, sanitizeParam(voltageLevelsIds.toString()), depth);
-        String svg = networkAeraDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
+        Pair<String, Integer> svg = networkAreaDiagramService.generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth);
         return OBJECT_MAPPER.writeValueAsString(
                 OBJECT_MAPPER.createObjectNode()
-                        .put(SVG_TAG, svg)
+                    .put(SVG_TAG, svg.getLeft())
+                    .putPOJO("metadata", OBJECT_MAPPER.createObjectNode().put(NB_VOLTAGE_LEVELS_TAG, svg.getRight()))
         );
     }
 }

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -48,6 +48,7 @@ public class SingleLineDiagramController {
     static final String HORIZONTAL = "horizontal";
     static final String SVG_TAG = "svg";
     static final String NB_VOLTAGE_LEVELS_TAG = "nbVoltageLevels";
+    static final String METADATA = "metadata";
 
     @Autowired
     private SingleLineDiagramService singleLineDiagramService;
@@ -145,7 +146,7 @@ public class SingleLineDiagramController {
         return OBJECT_MAPPER.writeValueAsString(
                 OBJECT_MAPPER.createObjectNode()
                     .put(SVG_TAG, svg)
-                    .putRawValue("metadata", new RawValue(metadata)));
+                    .putRawValue(METADATA, new RawValue(metadata)));
     }
 
     // substations
@@ -240,7 +241,7 @@ public class SingleLineDiagramController {
         return OBJECT_MAPPER.writeValueAsString(
                 OBJECT_MAPPER.createObjectNode()
                         .put(SVG_TAG, svg)
-                        .putRawValue("metadata", new RawValue(metadata)));
+                        .putRawValue(METADATA, new RawValue(metadata)));
     }
 
     @GetMapping(value = "/svg-component-libraries")
@@ -266,7 +267,7 @@ public class SingleLineDiagramController {
         return OBJECT_MAPPER.writeValueAsString(
                 OBJECT_MAPPER.createObjectNode()
                     .put(SVG_TAG, svg.getLeft())
-                    .putPOJO("metadata", OBJECT_MAPPER.createObjectNode().put(NB_VOLTAGE_LEVELS_TAG, svg.getRight()))
+                    .putPOJO(METADATA, OBJECT_MAPPER.createObjectNode().put(NB_VOLTAGE_LEVELS_TAG, svg.getRight()))
         );
     }
 }

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -282,6 +282,7 @@ public class SingleLineDiagramTest {
                 .andReturn();
         String stringResult = result.getResponse().getContentAsString();
         assertTrue(stringResult.contains("svg"));
+        assertTrue(stringResult.contains("metadata"));
         assertTrue(stringResult.contains("<?xml"));
 
         result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&depth=2" + "&voltageLevelsIds=vlFr1A", testNetworkId))
@@ -290,6 +291,7 @@ public class SingleLineDiagramTest {
                 .andReturn();
         String stringResult2 = result.getResponse().getContentAsString();
         assertTrue(stringResult2.contains("svg"));
+        assertTrue(stringResult.contains("metadata"));
         assertTrue(stringResult2.contains("<?xml"));
 
         mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&depth=2" + "&voltageLevelsIds=notFound", testNetworkId))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Only the svg is returned in the call to get a network area diagram


**What is the new behavior (if this is a feature change)?**
Add the number of voltage levels in the nad, in addition to the svg


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
