### PR TITLE
Send the full list of displayed Voltage Levels in the NAD additionalMetadata

### DIFF
--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -116,9 +116,7 @@ class NetworkAreaDiagramService {
         Optional.ofNullable(nadConfigInfos.getVoltageLevelIds()).ifPresent(voltageLevels ->
             entity.setVoltageLevelIds(new ArrayList<>(voltageLevels))
         );
-        Optional.ofNullable(nadConfigInfos.getDepth()).ifPresent(entity::setDepth);
         Optional.ofNullable(nadConfigInfos.getScalingFactor()).ifPresent(entity::setScalingFactor);
-        Optional.ofNullable(nadConfigInfos.getRadiusFactor()).ifPresent(entity::setRadiusFactor);
 
         if (nadConfigInfos.getPositions() != null && !nadConfigInfos.getPositions().isEmpty()) {
             updatePositions(entity, nadConfigInfos);
@@ -252,8 +250,8 @@ class NetworkAreaDiagramService {
                 .setSvgWidthAndHeightAdded(true)
                 .setCssLocation(SvgParameters.CssLocation.EXTERNAL_NO_IMPORT);
 
-        //List of selected voltageLevels with depth
-        VoltageLevelFilter vlFilter = VoltageLevelFilter.createVoltageLevelsDepthFilter(network, existingVLIds, nadConfigInfos.getDepth());
+        //List of selected voltageLevels with depth (zero at the moment, as depth modification is disabled for NAD generated from a config)
+        VoltageLevelFilter vlFilter = VoltageLevelFilter.createVoltageLevelsDepthFilter(network, existingVLIds, 0);
 
         LayoutParameters layoutParameters = new LayoutParameters();
         NadParameters nadParameters = new NadParameters();

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -270,7 +270,7 @@ class NetworkAreaDiagramService {
         LayoutFactory layoutFactory = new FixedLayoutFactory(positionsForFixedLayout, BasicForceLayout::new);
         nadParameters.setLayoutFactory(layoutFactory);
 
-        return drawSvgAndBuildMetadata(network, nadParameters, vlFilter, existingVLIds, nadConfigInfos.getDepth(), nadConfigInfos.getScalingFactor());
+        return drawSvgAndBuildMetadata(network, nadParameters, vlFilter, nadConfigInfos.getScalingFactor());
     }
 
     public SvgAndMetadata generateNetworkAreaDiagramSvg(UUID networkUuid, String variantId, List<String> voltageLevelsIds, int depth, boolean withGeoData) {
@@ -318,13 +318,13 @@ class NetworkAreaDiagramService {
         }
         nadParameters.setStyleProviderFactory(n -> new TopologicalStyleProvider(network));
 
-        return drawSvgAndBuildMetadata(network, nadParameters, vlFilter, existingVLIds, depth, scalingFactor);
+        return drawSvgAndBuildMetadata(network, nadParameters, vlFilter, scalingFactor);
     }
 
-    private SvgAndMetadata drawSvgAndBuildMetadata(Network network, NadParameters nadParameters, VoltageLevelFilter vlFilter, List<String> existingVLIds, int depth, int scalingFactor) {
+    private SvgAndMetadata drawSvgAndBuildMetadata(Network network, NadParameters nadParameters, VoltageLevelFilter vlFilter, Integer scalingFactor) {
         try (StringWriter svgWriter = new StringWriter(); StringWriter metadataWriter = new StringWriter()) {
             NetworkAreaDiagram.draw(network, svgWriter, metadataWriter, nadParameters, vlFilter);
-            Map<String, Object> additionalMetadata = computeAdditionalMetadata(network, existingVLIds, depth, scalingFactor);
+            Map<String, Object> additionalMetadata = computeAdditionalMetadata(vlFilter, scalingFactor);
 
             return SvgAndMetadata.builder()
                     .svg(svgWriter.toString())
@@ -361,12 +361,9 @@ class NetworkAreaDiagramService {
         return substationGeoDataMap;
     }
 
-    private Map<String, Object> computeAdditionalMetadata(Network network, List<String> voltageLevelsIds, int depth, int scalingFactor) {
+    private Map<String, Object> computeAdditionalMetadata(VoltageLevelFilter vlFilter, Integer scalingFactor) {
 
-        VoltageLevelFilter vlFilter = VoltageLevelFilter.createVoltageLevelsDepthFilter(network, voltageLevelsIds, depth);
-
-        List<VoltageLevelInfos> voltageLevelsInfos = voltageLevelsIds.stream()
-                .map(network::getVoltageLevel)
+        List<VoltageLevelInfos> voltageLevelsInfos = vlFilter.getVoltageLevels().stream()
                 .map(VoltageLevelInfos::new)
                 .toList();
 

--- a/src/main/java/com/powsybl/sld/server/dto/nad/NadConfigInfos.java
+++ b/src/main/java/com/powsybl/sld/server/dto/nad/NadConfigInfos.java
@@ -25,10 +25,7 @@ public class NadConfigInfos {
     private UUID id;
     @Builder.Default
     private List<String> voltageLevelIds = new ArrayList<>();
-    @Builder.Default
-    private Integer depth = 0;
     private Integer scalingFactor;
-    private Double radiusFactor;
     @Builder.Default
     private List<NadVoltageLevelPositionInfos> positions = new ArrayList<>();
 
@@ -36,9 +33,7 @@ public class NadConfigInfos {
         return NadConfigEntity.builder()
                 .id(id)
                 .voltageLevelIds(voltageLevelIds)
-                .depth(depth)
                 .scalingFactor(scalingFactor)
-                .radiusFactor(radiusFactor)
                 .positions(positions.stream().map(NadVoltageLevelPositionInfos::toEntity).toList())
                 .build();
     }

--- a/src/main/java/com/powsybl/sld/server/entities/nad/NadConfigEntity.java
+++ b/src/main/java/com/powsybl/sld/server/entities/nad/NadConfigEntity.java
@@ -25,9 +25,7 @@ import java.util.*;
 public class NadConfigEntity {
 
     public NadConfigEntity(NadConfigEntity origin) {
-        this.depth = origin.getDepth();
         this.scalingFactor = origin.getScalingFactor();
-        this.radiusFactor = origin.getRadiusFactor();
         this.voltageLevelIds = new ArrayList<>();
         this.voltageLevelIds.addAll(origin.getVoltageLevelIds());
         this.positions = new ArrayList<>();
@@ -47,14 +45,8 @@ public class NadConfigEntity {
     @Builder.Default
     private List<String> voltageLevelIds = new ArrayList<>();
 
-    @Column(name = "depth")
-    private Integer depth;
-
     @Column(name = "scalingFactor")
     private Integer scalingFactor;
-
-    @Column(name = "radiusFactor")
-    private Double radiusFactor;
 
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "nad_config_id")
@@ -65,9 +57,7 @@ public class NadConfigEntity {
         NadConfigInfos.NadConfigInfosBuilder nadConfigInfosBuilder = NadConfigInfos.builder();
         nadConfigInfosBuilder.id(this.id)
                 .voltageLevelIds(this.voltageLevelIds)
-                .depth(this.depth)
                 .scalingFactor(this.scalingFactor)
-                .radiusFactor(this.radiusFactor)
                 .build();
         nadConfigInfosBuilder.positions(this.positions.stream().map(NadVoltageLevelPositionEntity::toDto).toList());
         return nadConfigInfosBuilder.build();

--- a/src/main/resources/db/changelog/changesets/changelog_20250326T163426Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20250326T163426Z.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="boutiercha (generated)" id="1743006883426-1">
+        <dropColumn columnName="DEPTH" tableName="NAD_CONFIG"/>
+    </changeSet>
+    <changeSet author="boutiercha (generated)" id="1743006883426-2">
+        <dropColumn columnName="RADIUS_FACTOR" tableName="NAD_CONFIG"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -6,3 +6,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20250310T113328Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20250326T163426Z.xml
+      relativeToChangelogFile: true

--- a/src/test/java/com/powsybl/sld/server/DiagramConfigRepositoryTest.java
+++ b/src/test/java/com/powsybl/sld/server/DiagramConfigRepositoryTest.java
@@ -42,9 +42,7 @@ class DiagramConfigRepositoryTest {
     NadConfigEntity createNadConfigEntity() {
         return NadConfigEntity.builder()
                 .voltageLevelIds(List.of("VL1", "VL2"))
-                .depth(0)
                 .scalingFactor(0)
-                .radiusFactor(0.0)
                 .positions(
                         List.of(
                                 NadVoltageLevelPositionEntity.builder()

--- a/src/test/java/com/powsybl/sld/server/NetworkAreaDiagramServiceTest.java
+++ b/src/test/java/com/powsybl/sld/server/NetworkAreaDiagramServiceTest.java
@@ -66,8 +66,6 @@ class NetworkAreaDiagramServiceTest {
 
         return NadConfigInfos.builder()
                 .voltageLevelIds(List.of("VL1"))
-                .depth(1)
-                .radiusFactor(100.0)
                 .scalingFactor(300000)
                 .positions(positions)
                 .build();
@@ -84,7 +82,6 @@ class NetworkAreaDiagramServiceTest {
 
         NadConfigInfos nadConfigDto = networkAreaDiagramService.getNetworkAreaDiagramConfig(nadConfigId);
 
-        assertEquals(1, nadConfigDto.getDepth());
         assertEquals(1, nadConfigDto.getVoltageLevelIds().size());
         assertEquals(2, nadConfigDto.getPositions().size());
 
@@ -134,7 +131,6 @@ class NetworkAreaDiagramServiceTest {
 
         // Test before update
         NadConfigInfos nadConfigDtoPreUpdate = networkAreaDiagramService.getNetworkAreaDiagramConfig(nadConfigId);
-        assertEquals(1, nadConfigDtoPreUpdate.getDepth());
         assertEquals(1, nadConfigDtoPreUpdate.getVoltageLevelIds().size());
         assertEquals(300000, nadConfigDtoPreUpdate.getScalingFactor());
         assertEquals(2, nadConfigDtoPreUpdate.getPositions().size());
@@ -146,7 +142,6 @@ class NetworkAreaDiagramServiceTest {
 
         // Update
         NadConfigInfos nadConfigUpdate = new NadConfigInfos();
-        nadConfigUpdate.setDepth(18);
         nadConfigUpdate.setScalingFactor(600000);
         nadConfigUpdate.setVoltageLevelIds(List.of("VL1", "VL2"));
 
@@ -175,7 +170,6 @@ class NetworkAreaDiagramServiceTest {
 
         // Test after update
         NadConfigInfos nadConfigDtoPostUpdate = networkAreaDiagramService.getNetworkAreaDiagramConfig(nadConfigId);
-        assertEquals(18, nadConfigDtoPostUpdate.getDepth());
         assertEquals(2, nadConfigDtoPostUpdate.getVoltageLevelIds().size());
         assertEquals(600000, nadConfigDtoPostUpdate.getScalingFactor());
         assertEquals(3, nadConfigDtoPostUpdate.getPositions().size());

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -359,18 +359,14 @@ class SingleLineDiagramTest {
                 .id(nadConfigUuid)
                 .voltageLevelIds(List.of("vlFr1A"))
                 .scalingFactor(0)
-                .radiusFactor(0.0)
                 .positions(List.of())
-                .depth(0)
                 .build();
 
         NadConfigInfos nadConfigInfosVlNotFound = NadConfigInfos.builder()
                 .id(nadConfigUuidVlNotFound)
                 .voltageLevelIds(List.of("notFound"))
                 .scalingFactor(0)
-                .radiusFactor(0.0)
                 .positions(List.of())
-                .depth(0)
                 .build();
 
         given(networkStoreService.getNetwork(testNetworkId, PreloadingStrategy.COLLECTION)).willReturn(createNetwork());


### PR DESCRIPTION
- Code optimization

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

The additional metadata provided when generating a NAD now includes the list of all the visible voltage levels, regardless of the depth used to generate the NAD.

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
