### PR TITLE
Open a NAD from a filter

### DIFF
--- a/src/main/java/com/powsybl/sld/server/FilterService.java
+++ b/src/main/java/com/powsybl/sld/server/FilterService.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.server;
 
 import com.powsybl.sld.server.dto.IdentifiableAttributes;
+import lombok.NonNull;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,6 @@ import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -49,9 +49,7 @@ public class FilterService {
         return this.filterServerBaseUri + DELIMITER + FILTER_API_VERSION + DELIMITER;
     }
 
-    public List<IdentifiableAttributes> exportFilter(UUID networkUuid, String variantId, UUID filterUuid) {
-        Objects.requireNonNull(networkUuid);
-        Objects.requireNonNull(filterUuid);
+    public List<IdentifiableAttributes> exportFilter(@NonNull UUID networkUuid, String variantId, @NonNull UUID filterUuid) {
         String endPointUrl = getFilterServerURI() + FILTER_END_POINT_EXPORT;
 
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(endPointUrl);

--- a/src/main/java/com/powsybl/sld/server/FilterService.java
+++ b/src/main/java/com/powsybl/sld/server/FilterService.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.server;
+
+import com.powsybl.sld.server.dto.IdentifiableAttributes;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * @author Charly BOUTIER <charly.boutier at rte-france.com>
+ */
+
+@Service
+public class FilterService {
+
+    public static final String FILTER_API_VERSION = "v1";
+    public static final String QUERY_PARAM_VARIANT_ID = "variantId";
+    public static final String QUERY_PARAM_NETWORK_UUID = "networkUuid";
+    private static final String DELIMITER = "/";
+    private final RestTemplate restTemplate;
+    @Setter
+    private String filterServerBaseUri;
+
+    public static final String FILTER_END_POINT_EXPORT = "/filters/{id}/export";
+
+    public FilterService(@Value("${gridsuite.services.filter-server.base-uri:http://filter-server/}") String filterServerBaseUri,
+                          RestTemplate restTemplate) {
+        this.filterServerBaseUri = filterServerBaseUri;
+        this.restTemplate = restTemplate;
+    }
+
+    private String getFilterServerURI() {
+        return this.filterServerBaseUri + DELIMITER + FILTER_API_VERSION + DELIMITER;
+    }
+
+    public List<IdentifiableAttributes> exportFilter(UUID networkUuid, String variantId, UUID filterUuid) {
+        Objects.requireNonNull(networkUuid);
+        Objects.requireNonNull(filterUuid);
+        String endPointUrl = getFilterServerURI() + FILTER_END_POINT_EXPORT;
+
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(endPointUrl);
+        uriComponentsBuilder.queryParam(QUERY_PARAM_NETWORK_UUID, networkUuid);
+        if (variantId != null && !variantId.isBlank()) {
+            uriComponentsBuilder.queryParam(QUERY_PARAM_VARIANT_ID, variantId);
+        }
+        var uriComponent = uriComponentsBuilder.buildAndExpand(filterUuid);
+        return restTemplate.exchange(uriComponent.toUriString(), HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<IdentifiableAttributes>>() {
+                }).getBody();
+    }
+}

--- a/src/main/java/com/powsybl/sld/server/FilterService.java
+++ b/src/main/java/com/powsybl/sld/server/FilterService.java
@@ -10,7 +10,9 @@ import com.powsybl.sld.server.dto.IdentifiableAttributes;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import lombok.Setter;
@@ -58,8 +60,13 @@ public class FilterService {
             uriComponentsBuilder.queryParam(QUERY_PARAM_VARIANT_ID, variantId);
         }
         var uriComponent = uriComponentsBuilder.buildAndExpand(filterUuid);
-        return restTemplate.exchange(uriComponent.toUriString(), HttpMethod.GET, null,
-                new ParameterizedTypeReference<List<IdentifiableAttributes>>() {
-                }).getBody();
+
+        try {
+            return restTemplate.exchange(uriComponent.toUriString(), HttpMethod.GET, null,
+                    new ParameterizedTypeReference<List<IdentifiableAttributes>>() {
+                    }).getBody();
+        } catch (HttpStatusCodeException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -23,17 +23,15 @@ import com.powsybl.nad.svg.SvgParameters;
 import com.powsybl.nad.svg.iidm.TopologicalStyleProvider;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.client.PreloadingStrategy;
-import com.powsybl.sld.server.dto.Coordinate;
-import com.powsybl.sld.server.dto.SubstationGeoData;
-import com.powsybl.sld.server.dto.SvgAndMetadata;
-import com.powsybl.sld.server.dto.VoltageLevelInfos;
+import com.powsybl.sld.server.dto.*;
+import com.powsybl.sld.server.dto.nad.ElementParametersInfos;
 import com.powsybl.sld.server.dto.nad.NadConfigInfos;
 import com.powsybl.sld.server.dto.nad.NadVoltageLevelPositionInfos;
 import com.powsybl.sld.server.entities.nad.NadConfigEntity;
 import com.powsybl.sld.server.entities.nad.NadVoltageLevelPositionEntity;
 import com.powsybl.sld.server.repository.NadConfigRepository;
 import com.powsybl.sld.server.utils.DiagramUtils;
-import com.powsybl.sld.server.utils.GeoDataUtils;
+import com.powsybl.sld.server.utils.ResourceUtils;
 import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
 import org.springframework.context.annotation.ComponentScan;
@@ -67,6 +65,7 @@ class NetworkAreaDiagramService {
 
     private final NetworkStoreService networkStoreService;
     private final GeoDataService geoDataService;
+    private final FilterService filterService;
     private final NetworkAreaExecutionService diagramExecutionService;
 
     private final NadConfigRepository nadConfigRepository;
@@ -76,12 +75,14 @@ class NetworkAreaDiagramService {
 
     public NetworkAreaDiagramService(NetworkStoreService networkStoreService,
                                      GeoDataService geoDataService,
+                                     FilterService filterService,
                                      NetworkAreaExecutionService diagramExecutionService,
                                      NadConfigRepository nadConfigRepository,
                                      @Lazy NetworkAreaDiagramService networkAreaDiagramService,
                                      ObjectMapper objectMapper) {
         this.networkStoreService = networkStoreService;
         this.geoDataService = geoDataService;
+        this.filterService = filterService;
         this.diagramExecutionService = diagramExecutionService;
         this.nadConfigRepository = nadConfigRepository;
         this.self = networkAreaDiagramService;
@@ -162,15 +163,37 @@ class NetworkAreaDiagramService {
         return nadConfigRepository.findWithVoltageLevelIdsById(nadConfigUuid).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND)).toDto();
     }
 
+    @Transactional(readOnly = true)
+    public List<String> getVoltageLevelsIdsFromFilter(UUID networkUuid, String variantId, UUID filterUuid) {
+        List<IdentifiableAttributes> filterContent = filterService.exportFilter(networkUuid, variantId, filterUuid);
+        return filterContent.stream()
+            .map(IdentifiableAttributes::getId)
+            .collect(Collectors.toList());
+    }
+
     @Transactional
     public void deleteNetworkAreaDiagramConfig(UUID nadConfigUuid) {
         nadConfigRepository.deleteById(nadConfigUuid);
+    }
+
+    public String generateNetworkAreaDiagramSvgFromElement(UUID networkUuid, String variantId, @NonNull ElementParametersInfos elementParametersInfos) {
+        return switch(elementParametersInfos.getElementType()) {
+            case DIAGRAM_CONFIG -> generateNetworkAreaDiagramSvgFromConfigAsync(networkUuid, variantId, elementParametersInfos.getElementUuid());
+            case FILTER -> generateNetworkAreaDiagramSvgFromFilterAsync(networkUuid, variantId, elementParametersInfos.getElementUuid(), elementParametersInfos.getDepth(), elementParametersInfos.getWithGeoData());
+        };
     }
 
     public String generateNetworkAreaDiagramSvgFromConfigAsync(UUID networkUuid, String variantId, UUID nadConfigUuid) {
         return diagramExecutionService
                 .supplyAsync(() -> self.getNetworkAreaDiagramConfig(nadConfigUuid))
                 .thenApply(nadConfigInfos -> processSvgAndMetadata(generateNetworkAreaDiagramSvgFromConfig(networkUuid, variantId, nadConfigInfos)))
+                .join();
+    }
+
+    public String generateNetworkAreaDiagramSvgFromFilterAsync(UUID networkUuid, String variantId, UUID filterUuid, Integer depth, Boolean withGeoData) {
+        return diagramExecutionService
+                .supplyAsync(() -> self.getVoltageLevelsIdsFromFilter(networkUuid, variantId, filterUuid))
+                .thenApply(voltageLevelsIds -> processSvgAndMetadata(generateNetworkAreaDiagramSvg(networkUuid, variantId, voltageLevelsIds, depth, withGeoData)))
                 .join();
     }
 
@@ -341,7 +364,7 @@ class NetworkAreaDiagramService {
                 .toList();
 
         String substationsGeoDataString = geoDataService.getSubstationsGraphics(networkUuid, variantId, substations.stream().map(Substation::getId).toList());
-        List<SubstationGeoData> substationsGeoData = GeoDataUtils.fromStringToSubstationGeoData(substationsGeoDataString, new ObjectMapper());
+        List<SubstationGeoData> substationsGeoData = ResourceUtils.fromStringToSubstationGeoData(substationsGeoDataString, new ObjectMapper());
         Map<String, Coordinate> substationGeoDataMap = substationsGeoData.stream()
                 .collect(Collectors.toMap(SubstationGeoData::getId, SubstationGeoData::getCoordinate));
 

--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -177,7 +177,7 @@ class NetworkAreaDiagramService {
     }
 
     public String generateNetworkAreaDiagramSvgFromElement(UUID networkUuid, String variantId, @NonNull ElementParametersInfos elementParametersInfos) {
-        return switch(elementParametersInfos.getElementType()) {
+        return switch (elementParametersInfos.getElementType()) {
             case DIAGRAM_CONFIG -> generateNetworkAreaDiagramSvgFromConfigAsync(networkUuid, variantId, elementParametersInfos.getElementUuid());
             case FILTER -> generateNetworkAreaDiagramSvgFromFilterAsync(networkUuid, variantId, elementParametersInfos.getElementUuid(), elementParametersInfos.getDepth(), elementParametersInfos.getWithGeoData());
         };

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.RawValue;
 import com.powsybl.sld.server.dto.SvgAndMetadata;
+import com.powsybl.sld.server.dto.nad.ElementParametersInfos;
 import com.powsybl.sld.server.dto.nad.NadConfigInfos;
+import com.powsybl.sld.server.utils.ResourceUtils;
 import com.powsybl.sld.server.utils.SingleLineDiagramParameters;
 import com.powsybl.sld.server.utils.SldDisplayMode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,11 +22,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -51,6 +56,9 @@ public class SingleLineDiagramController {
     private final SingleLineDiagramService singleLineDiagramService;
 
     private final NetworkAreaDiagramService networkAreaDiagramService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     public SingleLineDiagramController(SingleLineDiagramService singleLineDiagramService,
                                        NetworkAreaDiagramService networkAreaDiagramService) {
@@ -276,13 +284,16 @@ public class SingleLineDiagramController {
     }
 
     @GetMapping(value = "/network-area-diagram/{networkUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "Get network area diagram image")
+    @Operation(summary = "Get network area diagram image using an element")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The network area diagram svg")})
     public @ResponseBody String generateNetworkAreaDiagramSvgFromConfig(
             @Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
-            @Parameter(description = "Network area diagram UUID") @RequestParam(name = "nadConfigUuid") UUID nadConfigUuid) {
-        return networkAreaDiagramService.generateNetworkAreaDiagramSvgFromConfigAsync(networkUuid, variantId, nadConfigUuid);
+            @Parameter(description = "Element parameters") @RequestParam(name = "elementParams") String stringElementParams) {
+        ElementParametersInfos elementParams = ResourceUtils.fromStringToElementParametersInfos(
+                URLDecoder.decode(stringElementParams, StandardCharsets.UTF_8),
+                new ObjectMapper());
+        return networkAreaDiagramService.generateNetworkAreaDiagramSvgFromElement(networkUuid, variantId, elementParams);
     }
 
     @PostMapping(value = "/network-area-diagram/config", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -286,7 +286,7 @@ public class SingleLineDiagramController {
     @GetMapping(value = "/network-area-diagram/{networkUuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Get network area diagram image using an element")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The network area diagram svg")})
-    public @ResponseBody String generateNetworkAreaDiagramSvgFromConfig(
+    public @ResponseBody String generateNetworkAreaDiagramSvgFromElement(
             @Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @Parameter(description = "Element parameters") @RequestParam(name = "elementParams") String stringElementParams) {

--- a/src/main/java/com/powsybl/sld/server/dto/IdentifiableAttributes.java
+++ b/src/main/java/com/powsybl/sld/server/dto/IdentifiableAttributes.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.server.dto;
+
+import com.powsybl.iidm.network.IdentifiableType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Charly BOUTIER <charly.boutier at rte-france.com>
+ */
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Identifiable attributes")
+public class IdentifiableAttributes {
+
+    @Schema(description = "identifiable id")
+    private String id;
+
+    @Schema(description = "identifiable type")
+    private IdentifiableType type;
+
+    @Schema(description = "distribution key")
+    private Double distributionKey;
+}

--- a/src/main/java/com/powsybl/sld/server/dto/nad/ElementParametersInfos.java
+++ b/src/main/java/com/powsybl/sld/server/dto/nad/ElementParametersInfos.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.server.dto.nad;
+
+import com.powsybl.sld.server.utils.ElementType;
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * @author Charly Boutier <charly.boutier at rte-france.com>
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class ElementParametersInfos {
+    private UUID elementUuid;
+    private ElementType elementType;
+    @Builder.Default
+    private Integer depth = 0;
+    @Builder.Default
+    private Boolean withGeoData = true;
+}

--- a/src/main/java/com/powsybl/sld/server/utils/ElementType.java
+++ b/src/main/java/com/powsybl/sld/server/utils/ElementType.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.server.utils;
+
+/**
+ * @author Charly BOUTIER <charly.boutier at rte-france.com>
+ */
+public enum ElementType {
+    DIAGRAM_CONFIG,
+    FILTER
+}

--- a/src/main/java/com/powsybl/sld/server/utils/ResourceUtils.java
+++ b/src/main/java/com/powsybl/sld/server/utils/ResourceUtils.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.sld.server.dto.SubstationGeoData;
+import com.powsybl.sld.server.dto.nad.ElementParametersInfos;
 
 import java.util.List;
 
@@ -18,8 +19,8 @@ import java.util.List;
  * @author Maissa SOUISSI<maissa.souissi at rte-france.com>
  */
 
-public final class GeoDataUtils {
-    private GeoDataUtils() {
+public final class ResourceUtils {
+    private ResourceUtils() {
         throw new AssertionError("Utility class should not be instantiated");
     }
 
@@ -32,7 +33,13 @@ public final class GeoDataUtils {
         }
     }
 
+    public static ElementParametersInfos fromStringToElementParametersInfos(String jsonResponse, ObjectMapper objectMapper) {
+        try {
+            return objectMapper.readValue(jsonResponse, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new PowsyblException("Failed to parse JSON response", e);
+        }
+    }
+
 }
-
-
-

--- a/src/test/java/com/powsybl/sld/server/FilterServiceTest.java
+++ b/src/test/java/com/powsybl/sld/server/FilterServiceTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.server;
+
+import com.powsybl.iidm.network.IdentifiableType;
+import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.sld.server.dto.IdentifiableAttributes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class FilterServiceTest {
+    private static final String BASE_URI = "http://filter-server/";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private FilterService filterService;
+
+    @Mock
+    private NetworkStoreService networkStoreService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        filterService.setFilterServerBaseUri(BASE_URI);
+    }
+
+    @Test
+    void testExportFilter() {
+        UUID networkUuid = UUID.randomUUID();
+        UUID filterUuid = UUID.randomUUID();
+        String variantId = "variantA";
+
+        List<IdentifiableAttributes> expectedFilterContent = List.of(new IdentifiableAttributes("vlFr1A", IdentifiableType.VOLTAGE_LEVEL, null));
+        ResponseEntity<List<IdentifiableAttributes>> responseEntity = new ResponseEntity<>(expectedFilterContent, HttpStatus.OK);
+
+        when(restTemplate.exchange(
+                ArgumentMatchers.contains(filterUuid.toString()),
+                ArgumentMatchers.eq(HttpMethod.GET),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<IdentifiableAttributes>>>any())
+        ).thenReturn(responseEntity);
+
+        List<IdentifiableAttributes> result = filterService.exportFilter(networkUuid, variantId, filterUuid);
+
+        assertEquals(expectedFilterContent, result);
+    }
+
+    @Test
+    void testExportFilterNotFound() {
+        UUID networkUuid = UUID.randomUUID();
+        UUID filterUuid = UUID.randomUUID();
+        String variantId = "variantA";
+
+        when(restTemplate.exchange(
+                ArgumentMatchers.contains(filterUuid.toString()),
+                ArgumentMatchers.eq(HttpMethod.GET),
+                ArgumentMatchers.isNull(),
+                ArgumentMatchers.<ParameterizedTypeReference<List<IdentifiableAttributes>>>any())
+        ).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+        assertThrows(ResponseStatusException.class, () -> filterService.exportFilter(networkUuid, variantId, filterUuid));
+    }
+}

--- a/src/test/java/com/powsybl/sld/server/FilterServiceTest.java
+++ b/src/test/java/com/powsybl/sld/server/FilterServiceTest.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.server;
 import com.powsybl.iidm.network.IdentifiableType;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.sld.server.dto.IdentifiableAttributes;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -42,10 +43,17 @@ class FilterServiceTest {
     @Mock
     private NetworkStoreService networkStoreService;
 
+    private AutoCloseable mocks;
+
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         filterService.setFilterServerBaseUri(BASE_URI);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 
     @Test

--- a/src/test/java/com/powsybl/sld/server/GeoDataServiceTest.java
+++ b/src/test/java/com/powsybl/sld/server/GeoDataServiceTest.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.sld.server.dto.Coordinate;
 import com.powsybl.sld.server.dto.SubstationGeoData;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -37,10 +38,17 @@ class GeoDataServiceTest {
     @Mock
     private NetworkStoreService networkStoreService;
 
+    private AutoCloseable mocks;
+
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
+        mocks = MockitoAnnotations.openMocks(this);
         geoDataService.setGeoDataServerBaseUri(BASE_URI);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 
     @Test

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -361,8 +361,7 @@ class SingleLineDiagramTest {
         UUID filterUuid = UUID.randomUUID();
         UUID filterUuidNotFound = UUID.randomUUID();
 
-        List<IdentifiableAttributes> filterContent = new ArrayList<>();
-        filterContent.add(new IdentifiableAttributes("vlFr1A", IdentifiableType.VOLTAGE_LEVEL, null));
+        List<IdentifiableAttributes> filterContent = List.of(new IdentifiableAttributes("vlFr1A", IdentifiableType.VOLTAGE_LEVEL, null));
 
         given(geoDataService.getSubstationsGraphics(testNetworkId, VARIANT_2_ID, List.of("subFr1"))).willReturn(toString(GEO_DATA_SUBSTATIONS));
         given(networkStoreService.getNetwork(testNetworkId, PreloadingStrategy.COLLECTION)).willReturn(createNetwork());

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -47,6 +47,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.net.URLEncoder;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -373,7 +374,9 @@ class SingleLineDiagramTest {
         given(nadConfigRepository.findWithVoltageLevelIdsById(nadConfigUuid)).willReturn(Optional.ofNullable(nadConfigInfos.toEntity()));
         given(nadConfigRepository.findWithVoltageLevelIdsById(nadConfigUuidVlNotFound)).willReturn(Optional.ofNullable(nadConfigInfosVlNotFound.toEntity()));
 
-        MvcResult result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&nadConfigUuid=" + nadConfigUuid, testNetworkId))
+        String jsonElementParams = "{\"elementType\":\"DIAGRAM_CONFIG\",\"elementUuid\":\"" + nadConfigUuid + "\"}";
+
+        MvcResult result = mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&elementParams=" + URLEncoder.encode(jsonElementParams, StandardCharsets.UTF_8), testNetworkId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -383,7 +386,9 @@ class SingleLineDiagramTest {
         assertTrue(stringResult.contains("additionalMetadata"));
         assertTrue(stringResult.contains("<?xml"));
 
-        mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&nadConfigUuid=" + nadConfigUuidVlNotFound, testNetworkId))
+        String jsonElementParamsVlNotFound = "{\"elementType\":\"DIAGRAM_CONFIG\",\"elementUuid\":\"" + nadConfigUuidVlNotFound + "\"}";
+
+        mvc.perform(get("/v1/network-area-diagram/{networkUuid}?variantId=" + VARIANT_2_ID + "&elementParams=" + URLEncoder.encode(jsonElementParamsVlNotFound, StandardCharsets.UTF_8), testNetworkId))
                 .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
New feature : open a network area diagram from a voltage level filter.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
We cannot open a nad from a filter.


**What is the new behavior (if this is a feature change)?**
We can open a nad from a filter.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Update the calls to the API endpoint GET /network-area-diagram/{networkUuid} : instead of using a Nad diagram config UUID as a parameter, we now use a DTO (ElementParametersInfos) that contains the UUID and the type of element the UUID refers to.

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
