### PR TITLE
Use the saved label positions when generating a NAD

### DIFF
--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -73,6 +73,8 @@ class NetworkAreaDiagramService {
     private static final int MIN_SCALING_FACTOR = 50000;
     private static final int MAX_SCALING_FACTOR = 600000;
     private static final double RADIUS_FACTOR = 300;
+    private static final double DEFAULT_X_LABEL_POSITION = 100.0;
+    private static final double DEFAULT_Y_LABEL_POSITION = -40.0;
 
     static final String SVG_TAG = "svg";
     static final String METADATA = "metadata";
@@ -365,12 +367,26 @@ class NetworkAreaDiagramService {
     }
 
     private LayoutFactory prepareFixedLayoutFactory(NadGenerationContext nadGenerationContext) {
-        Map<String, Point> positionsForFixedLayout = nadGenerationContext.getPositions().stream()
-            .collect(Collectors.toMap(
-                NadVoltageLevelPositionInfos::getVoltageLevelId,
-                info -> new Point(info.getXPosition(), info.getYPosition())
-            ));
-        return new FixedLayoutFactory(positionsForFixedLayout, BasicForceLayout::new);
+        Map<String, Point> positionsForFixedLayout = new HashMap<>();
+        Map<String, TextPosition> textNodesPositionsForFixedLayout = new HashMap<>();
+
+        nadGenerationContext.getPositions().forEach(info -> {
+            positionsForFixedLayout.put(
+                    info.getVoltageLevelId(),
+                    new Point(info.getXPosition(), info.getYPosition())
+            );
+            textNodesPositionsForFixedLayout.put(
+                    info.getVoltageLevelId(),
+                    new TextPosition(
+                            new Point(
+                                    Optional.ofNullable(info.getXLabelPosition()).orElse(DEFAULT_X_LABEL_POSITION),
+                                    Optional.ofNullable(info.getYLabelPosition()).orElse(DEFAULT_Y_LABEL_POSITION)),
+                            new Point(0, 0)
+                    )
+            );
+        });
+
+        return new FixedLayoutFactory(positionsForFixedLayout, textNodesPositionsForFixedLayout, BasicForceLayout::new);
     }
 
     private String processSvgAndMetadata(SvgAndMetadata svgAndMetadata) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
When loading a NAD from a config, the saved label positions are used if they exist.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
