### PR TITLE
No longer block the tomcat thread when waiting for nads (servlet 3.0+ AsyncContext)

### DIFF
--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -56,6 +56,7 @@ import org.supercsv.io.CsvMapReader;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -211,8 +212,8 @@ class NetworkAreaDiagramService {
         nadConfigRepository.deleteById(nadConfigUuid);
     }
 
-    public String generateNetworkAreaDiagramSvgAsync(UUID networkUuid, String variantId, NadRequestInfos nadRequestInfos) {
-        return diagramExecutionService.supplyAsync(() -> self.generateNetworkAreaDiagramSvg(networkUuid, variantId, nadRequestInfos)).join();
+    public CompletableFuture<String> generateNetworkAreaDiagramSvgAsync(UUID networkUuid, String variantId, NadRequestInfos nadRequestInfos) {
+        return diagramExecutionService.supplyAsync(() -> self.generateNetworkAreaDiagramSvg(networkUuid, variantId, nadRequestInfos));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
+++ b/src/main/java/com/powsybl/sld/server/SingleLineDiagramController.java
@@ -31,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static com.powsybl.sld.server.NetworkAreaDiagramService.*;
 import static com.powsybl.ws.commons.LogUtils.sanitizeParam;
@@ -269,7 +270,7 @@ public class SingleLineDiagramController {
     @PostMapping(value = "/network-area-diagram/{networkUuid}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Get network area diagram image")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The network area diagram svg")})
-    public String generateNetworkAreaDiagramSvg(
+    public CompletableFuture<String> generateNetworkAreaDiagramSvg(
             @Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
             @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
             @RequestBody NadRequestInfos nadRequestInfos) {

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -378,7 +378,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(result))
+        result = mvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -404,8 +404,8 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfosNotFound)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(mvcResult))
-                .andExpect(status().isNotFound());
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
@@ -437,7 +437,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestWithValidFilter)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(validResult))
+        validResult = mvc.perform(asyncDispatch(validResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -462,8 +462,8 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(invalidFilterNadRequestJson)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(mvcResult))
-                .andExpect(status().isNotFound());
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isNotFound()).andReturn();
     }
 
     @Test
@@ -499,7 +499,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(requestWithValidConfig)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(validResult))
+        validResult = mvc.perform(asyncDispatch(validResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -552,7 +552,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(requestWithPositionFromNadConfig)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(firstResult))
+        firstResult = mvc.perform(asyncDispatch(firstResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -585,7 +585,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(requestWithPositionsFromUser)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(secondResult))
+        secondResult = mvc.perform(asyncDispatch(secondResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -612,7 +612,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(requestWithPositionsFromBoth)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(thirdResult))
+        thirdResult = mvc.perform(asyncDispatch(thirdResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -658,8 +658,8 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(requestWithValidConfig)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(mvcResult))
-                .andExpect(status().isOk());
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isOk()).andReturn();
 
         verify(geoDataService, times(0)).getSubstationsGraphics(any(), any(), any());
     }
@@ -697,8 +697,8 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(requestWithValidConfig)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(mvcResult))
-                .andExpect(status().isNotFound());
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isNotFound()).andReturn();
     }
 
     @ParameterizedTest
@@ -787,7 +787,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(result))
+        result = mvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
                 .andReturn();
         String stringResult = result.getResponse().getContentAsString();
@@ -815,7 +815,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(mvcResult))
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isBadRequest())
                 .andReturn();
 
@@ -841,7 +841,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfosExtendedVl)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(resultExtendedVl))
+        resultExtendedVl = mvc.perform(asyncDispatch(resultExtendedVl))
                 .andExpect(status().isOk())
                 .andReturn();
         String stringResultExtendedVl = resultExtendedVl.getResponse().getContentAsString();
@@ -953,7 +953,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestNoOmition)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(resultNoOmition))
+        resultNoOmition = mvc.perform(asyncDispatch(resultNoOmition))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -980,7 +980,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestWithOmition)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(resultWithOmition))
+        resultWithOmition = mvc.perform(asyncDispatch(resultWithOmition))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -1021,7 +1021,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestWithOmitionAndExtension)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(resultWithOmitionAndExtension))
+        resultWithOmitionAndExtension = mvc.perform(asyncDispatch(resultWithOmitionAndExtension))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -1056,9 +1056,10 @@ class SingleLineDiagramTest {
                 .content(objectMapper.writeValueAsString(nadRequestInfos)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        String errorMessage = mvc.perform(asyncDispatch(mvcResult))
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
             .andExpect(status().isForbidden())
-            .andReturn().getResponse().getErrorMessage();
+            .andReturn();
+        String errorMessage = mvcResult.getResponse().getErrorMessage();
         assertEquals(String.format("You need to reduce the number of voltage levels to be displayed in the network area diagram (current %s, maximum %s)", vlIds.size(), maxVls), errorMessage);
     }
 
@@ -1342,7 +1343,7 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(result))
+        result = mvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
                 .andReturn();
         String stringResult = result.getResponse().getContentAsString();
@@ -1365,8 +1366,8 @@ class SingleLineDiagramTest {
                         .content(objectMapper.writeValueAsString(nadRequestInfosVlNotFound)))
                 .andExpect(request().asyncStarted())
                 .andReturn();
-        mvc.perform(asyncDispatch(mvcResult))
-                .andExpect(status().isNotFound());
+        mvcResult = mvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isNotFound()).andReturn();
     }
 
     @Test

--- a/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
+++ b/src/test/java/com/powsybl/sld/server/SingleLineDiagramTest.java
@@ -79,6 +79,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -375,6 +376,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -394,10 +398,13 @@ class SingleLineDiagramTest {
                 .nadPositionsGenerationMode(NadPositionsGenerationMode.GEOGRAPHICAL_COORDINATES)
                 .build();
 
-        mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfosNotFound)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isNotFound());
     }
 
@@ -428,6 +435,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestWithValidFilter)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(validResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -446,10 +456,13 @@ class SingleLineDiagramTest {
                 .positions(Collections.emptyList())
                 .build();
 
-        mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidFilterNadRequestJson)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isNotFound());
     }
 
@@ -484,6 +497,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestWithValidConfig)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(validResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -534,6 +550,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestWithPositionFromNadConfig)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(firstResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -564,6 +583,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestWithPositionsFromUser)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(secondResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -588,6 +610,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestWithPositionsFromBoth)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(thirdResult))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -627,10 +652,13 @@ class SingleLineDiagramTest {
                 .nadPositionsGenerationMode(NadPositionsGenerationMode.AUTOMATIC)
                 .build();
 
-        mvc.perform(post("/v1/network-area-diagram/{networkUuid}", networkUuid)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", networkUuid)
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestWithValidConfig)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isOk());
 
         verify(geoDataService, times(0)).getSubstationsGraphics(any(), any(), any());
@@ -663,10 +691,13 @@ class SingleLineDiagramTest {
                 .nadPositionsGenerationMode(NadPositionsGenerationMode.AUTOMATIC)
                 .build();
 
-        mvc.perform(post("/v1/network-area-diagram/{networkUuid}", networkUuid)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", networkUuid)
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestWithValidConfig)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isNotFound());
     }
 
@@ -754,6 +785,9 @@ class SingleLineDiagramTest {
         MvcResult result = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
                 .andReturn();
         String stringResult = result.getResponse().getContentAsString();
@@ -776,9 +810,12 @@ class SingleLineDiagramTest {
                 .nadPositionsGenerationMode(NadPositionsGenerationMode.CONFIGURED)
                 .build();
 
-        mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isBadRequest())
                 .andReturn();
 
@@ -802,6 +839,9 @@ class SingleLineDiagramTest {
         MvcResult resultExtendedVl = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfosExtendedVl)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(resultExtendedVl))
                 .andExpect(status().isOk())
                 .andReturn();
         String stringResultExtendedVl = resultExtendedVl.getResponse().getContentAsString();
@@ -911,6 +951,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestNoOmition)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(resultNoOmition))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -935,6 +978,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestWithOmition)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(resultWithOmition))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -973,6 +1019,9 @@ class SingleLineDiagramTest {
         MvcResult resultWithOmitionAndExtension = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestWithOmitionAndExtension)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(resultWithOmitionAndExtension))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -1002,9 +1051,12 @@ class SingleLineDiagramTest {
             .nadPositionsGenerationMode(NadPositionsGenerationMode.AUTOMATIC)
             .build();
 
-        String errorMessage = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(nadRequestInfos)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        String errorMessage = mvc.perform(asyncDispatch(mvcResult))
             .andExpect(status().isForbidden())
             .andReturn().getResponse().getErrorMessage();
         assertEquals(String.format("You need to reduce the number of voltage levels to be displayed in the network area diagram (current %s, maximum %s)", vlIds.size(), maxVls), errorMessage);
@@ -1288,6 +1340,9 @@ class SingleLineDiagramTest {
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfos)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
                 .andReturn();
         String stringResult = result.getResponse().getContentAsString();
@@ -1304,10 +1359,13 @@ class SingleLineDiagramTest {
                 .positions(Collections.emptyList())
                 .build();
 
-        mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
+        MvcResult mvcResult = mvc.perform(post("/v1/network-area-diagram/{networkUuid}", testNetworkId)
                         .param("variantId", VARIANT_2_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(nadRequestInfosVlNotFound)))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        mvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
when generating a nad, the tomcat thread is blocked during the generation by the executor with only 3 threads


**What is the new behavior (if this is a feature change)?**
the tomcat thread is not blocked


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
When generating 20 nads, notice the number of tomcat threads

before
<img width="1684" height="1119" alt="image" src="https://github.com/user-attachments/assets/7a9784b0-6f14-4f3c-9a0a-ce61634c91d1" />

after
<img width="1684" height="1119" alt="image" src="https://github.com/user-attachments/assets/b0348465-17d1-4281-ad70-b34e1f7e6945" />



