### PR TITLE
Disable server timeouts (currently 30s) for asynccontext endpoints (nad)

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -2,6 +2,12 @@ spring:
   application:
     name: single-line-diagram-server
 
+  mvc:
+    async:
+      # To have the same behavior of no timeouts as regular endpoints for servlet 3.0+ asynccontext endpoints
+      # Can be removed when set as default in our common ws config
+      request-timeout: -1
+
 gridsuite:
   services:
     -


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
behavior revert


**What is the current behavior?**
<!-- You can also link to an open issue here -->
30s server timeout on nad

**What is the new behavior (if this is a feature change)?**
no timeout on nad  like before 6be05f45680c97b6e (#166)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Note: Eventually the configuration will in our shared config