### PR TITLE
Use a `VoltageLevelFilter` in `GeographicalLayoutFactory` to optimize Node missing position computation

### DIFF
--- a/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
+++ b/src/main/java/com/powsybl/sld/server/NetworkAreaDiagramService.java
@@ -361,12 +361,13 @@ class NetworkAreaDiagramService {
 
         // In order to draw half the lines that connect to the out of bound voltage levels, we have to know their coordinates.
         // To do so, we create a filter with a depth=1 that will include these out of bound voltage levels.
-        List<VoltageLevel> extendedVoltageLevelFilter = VoltageLevelFilter.createVoltageLevelsDepthFilter(
+        VoltageLevelFilter voltageLevelFilter = VoltageLevelFilter.createVoltageLevelsDepthFilter(
                 nadGenerationContext.getNetwork(),
                 new ArrayList<>(nadGenerationContext.getVoltageLevelIds()),
-                1).voltageLevels().stream().toList();
+                1);
+        List<VoltageLevel> extendedVoltageLevels = voltageLevelFilter.voltageLevels().stream().toList();
 
-        List<Substation> extendedSubstations = extendedVoltageLevelFilter.stream()
+        List<Substation> extendedSubstations = extendedVoltageLevels.stream()
                 .map(VoltageLevel::getNullableSubstation)
                 .filter(Objects::nonNull)
                 .toList();
@@ -389,7 +390,7 @@ class NetworkAreaDiagramService {
 
             nadGenerationContext.setScalingFactor(this.calculateScalingFactor(coordinatesForScaling));
         }
-        return new GeographicalLayoutFactory(nadGenerationContext.getNetwork(), nadGenerationContext.getScalingFactor(), RADIUS_FACTOR, BasicForceLayout::new);
+        return new GeographicalLayoutFactory(nadGenerationContext.getNetwork(), nadGenerationContext.getScalingFactor(), RADIUS_FACTOR, voltageLevelFilter, BasicForceLayout::new);
     }
 
     private LayoutFactory prepareFixedLayoutFactory(NadGenerationContext nadGenerationContext) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Even if a `VoltageLevelFilter` was considered in `prepareGeographicalLayoutFactory` it wasn't use to compute missing positions in 
`GeographicalLayoutFactory`. Then when fetching a simple NAD of 1 vl on a large network, it could compute missing position in the entire network even if not needed.


**What is the new behavior (if this is a feature change)?**
Use the exising `VoltageLevelFilter` built in `prepareGeographicalLayoutFactory` to construct a `GeographicalLayoutFactory` instance which will consider this filter to compute missing node positions

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Nothing, it's an optimization
